### PR TITLE
A first crack at getting MPI profiling information into NVVP.

### DIFF
--- a/libs/PMPIWrap/PMPIWrap.c
+++ b/libs/PMPIWrap/PMPIWrap.c
@@ -1,3 +1,6 @@
+/* This code was generated using the approach from the following article:
+ * https://devblogs.nvidia.com/gpu-pro-tip-track-mpi-calls-nvidia-visual-profiler/
+ */
 
 #include <mpi.h>
 #include <stdio.h>

--- a/libs/PMPIWrap/PMPIWrap.c
+++ b/libs/PMPIWrap/PMPIWrap.c
@@ -1,0 +1,514 @@
+
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef _EXTERN_C_
+#ifdef __cplusplus
+#define _EXTERN_C_ extern "C"
+#else /* __cplusplus */
+#define _EXTERN_C_
+#endif /* __cplusplus */
+#endif /* _EXTERN_C_ */
+
+#ifdef MPICH_HAS_C2F
+_EXTERN_C_ void *MPIR_ToPointer(int);
+#endif // MPICH_HAS_C2F
+
+#ifdef PIC
+/* For shared libraries, declare these weak and figure out which one was linked
+   based on which init wrapper was called.  See mpi_init wrappers.  */
+#pragma weak pmpi_init
+#pragma weak PMPI_INIT
+#pragma weak pmpi_init_
+#pragma weak pmpi_init__
+#endif /* PIC */
+
+_EXTERN_C_ void pmpi_init(MPI_Fint *ierr);
+_EXTERN_C_ void PMPI_INIT(MPI_Fint *ierr);
+_EXTERN_C_ void pmpi_init_(MPI_Fint *ierr);
+_EXTERN_C_ void pmpi_init__(MPI_Fint *ierr);
+
+#include <pthread.h>
+#include <nvToolsExt.h>
+#include <nvToolsExtCudaRt.h>
+
+/* ================== C Wrappers for MPI_Init ================== */
+_EXTERN_C_ int PMPI_Init(int *argc, char ***argv);
+_EXTERN_C_ int MPI_Init(int *argc, char ***argv) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxNameCategoryA(1000, "MPI");
+
+  _wrap_py_return_val = PMPI_Init(argc, argv);
+
+  int rank;
+  PMPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  char name[256];
+  sprintf( name, "MPI Rank %d", rank );
+ 
+  nvtxNameOsThread(pthread_self(), name);
+  nvtxNameCudaDeviceA(rank, name);
+    return _wrap_py_return_val;
+}
+
+
+
+/* ================== C Wrappers for MPI_Send ================== */
+_EXTERN_C_ int PMPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+_EXTERN_C_ int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Send";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Send(buf, count, datatype, dest, tag, comm);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Recv ================== */
+_EXTERN_C_ int PMPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status *status);
+_EXTERN_C_ int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status *status) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Recv";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Recv(buf, count, datatype, source, tag, comm, status);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Allreduce ================== */
+_EXTERN_C_ int PMPI_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+_EXTERN_C_ int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Allreduce";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Allreduce(sendbuf, recvbuf, count, datatype, op, comm);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Reduce ================== */
+_EXTERN_C_ int PMPI_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm);
+_EXTERN_C_ int MPI_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Reduce";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Reduce(sendbuf, recvbuf, count, datatype, op, root, comm);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Wait ================== */
+_EXTERN_C_ int PMPI_Wait(MPI_Request *request, MPI_Status *status);
+_EXTERN_C_ int MPI_Wait(MPI_Request *request, MPI_Status *status) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Wait";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Wait(request, status);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Waitany ================== */
+_EXTERN_C_ int PMPI_Waitany(int count, MPI_Request array_of_requests[], int *index, MPI_Status *status);
+_EXTERN_C_ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *index, MPI_Status *status) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Waitany";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Waitany(count, array_of_requests, index, status);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Waitall ================== */
+_EXTERN_C_ int PMPI_Waitall(int count, MPI_Request array_of_requests[], MPI_Status *array_of_statuses);
+_EXTERN_C_ int MPI_Waitall(int count, MPI_Request array_of_requests[], MPI_Status *array_of_statuses) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Waitall";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Waitall(count, array_of_requests, array_of_statuses);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Waitsome ================== */
+_EXTERN_C_ int PMPI_Waitsome(int incount, MPI_Request array_of_requests[], int *outcount, int array_of_indices[], MPI_Status array_of_statuses[]);
+_EXTERN_C_ int MPI_Waitsome(int incount, MPI_Request array_of_requests[], int *outcount, int array_of_indices[], MPI_Status array_of_statuses[]) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Waitsome";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Waitsome(incount, array_of_requests, outcount, array_of_indices, array_of_statuses);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Gather ================== */
+_EXTERN_C_ int PMPI_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
+_EXTERN_C_ int MPI_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Gather";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Gather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Gatherv ================== */
+_EXTERN_C_ int PMPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, int root, MPI_Comm comm);
+_EXTERN_C_ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, int root, MPI_Comm comm) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Gatherv";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Gatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Scatter ================== */
+_EXTERN_C_ int PMPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
+_EXTERN_C_ int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Scatter";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Scatter(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Scatterv ================== */
+_EXTERN_C_ int PMPI_Scatterv(const void *sendbuf, const int sendcounts[], const int displs[], MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
+_EXTERN_C_ int MPI_Scatterv(const void *sendbuf, const int sendcounts[], const int displs[], MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Scatterv";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Scatterv(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Allgather ================== */
+_EXTERN_C_ int PMPI_Allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+_EXTERN_C_ int MPI_Allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Allgather";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Allgatherv ================== */
+_EXTERN_C_ int PMPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm);
+_EXTERN_C_ int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Allgatherv";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Allgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Alltoall ================== */
+_EXTERN_C_ int PMPI_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+_EXTERN_C_ int MPI_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Alltoall";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Alltoall(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Alltoallv ================== */
+_EXTERN_C_ int PMPI_Alltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm);
+_EXTERN_C_ int MPI_Alltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Alltoallv";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Alltoallw ================== */
+_EXTERN_C_ int PMPI_Alltoallw(const void *sendbuf, const int sendcounts[], const int sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const int rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm);
+_EXTERN_C_ int MPI_Alltoallw(const void *sendbuf, const int sendcounts[], const int sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const int rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Alltoallw";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Alltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Bcast ================== */
+_EXTERN_C_ int PMPI_Bcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm);
+_EXTERN_C_ int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Bcast";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Bcast(buffer, count, datatype, root, comm);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Sendrecv ================== */
+_EXTERN_C_ int PMPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, int dest, int sendtag, void *recvbuf, int recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Status *status);
+_EXTERN_C_ int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, int dest, int sendtag, void *recvbuf, int recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Status *status) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Sendrecv";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Sendrecv(sendbuf, sendcount, sendtype, dest, sendtag, recvbuf, recvcount, recvtype, source, recvtag, comm, status);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Barrier ================== */
+_EXTERN_C_ int PMPI_Barrier(MPI_Comm comm);
+_EXTERN_C_ int MPI_Barrier(MPI_Comm comm) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Barrier";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Barrier(comm);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Start ================== */
+_EXTERN_C_ int PMPI_Start(MPI_Request *request);
+_EXTERN_C_ int MPI_Start(MPI_Request *request) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Start";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Start(request);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Test ================== */
+_EXTERN_C_ int PMPI_Test(MPI_Request *request, int *flag, MPI_Status *status);
+_EXTERN_C_ int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Test";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Test(request, flag, status);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Send_init ================== */
+_EXTERN_C_ int PMPI_Send_init(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+_EXTERN_C_ int MPI_Send_init(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Send_init";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Send_init(buf, count, datatype, dest, tag, comm, request);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+/* ================== C Wrappers for MPI_Recv_init ================== */
+_EXTERN_C_ int PMPI_Recv_init(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request);
+_EXTERN_C_ int MPI_Recv_init(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request) { 
+    int _wrap_py_return_val = 0;
+
+  nvtxEventAttributes_t eventAttrib = {0};
+
+  eventAttrib.version = NVTX_VERSION;
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  eventAttrib.message.ascii  = "MPI_Recv_init";
+  eventAttrib.category = 1000;
+ 
+  nvtxRangePushEx(&eventAttrib);
+  _wrap_py_return_val = PMPI_Recv_init(buf, count, datatype, source, tag, comm, request);
+  nvtxRangePop();
+    return _wrap_py_return_val;
+}
+
+

--- a/libs/PMPIWrap/makefile
+++ b/libs/PMPIWrap/makefile
@@ -1,0 +1,11 @@
+WRAP := ../../3rdParty/wrap/wrap.py
+CC   := mpicc
+
+PMPIWrap.a: PMPIWrap.o
+	$(AR) -cr libPMPIWrap.a PMPIWrap.o
+
+PMPIWrap.o: PMPIWrap.c
+	$(CC) $(CFLAGS) -o PMPIWrap.o -c PMPIWrap.c
+
+clean:
+	rm -f PMPIWrap.a PMPIWrap.o

--- a/solvers/elliptic/makefile
+++ b/solvers/elliptic/makefile
@@ -135,7 +135,13 @@ LOBJS = \
 ../../src/occaHostMallocPinned.o \
 ../../src/timer.o
 
-ellipticMain:$(AOBJS) $(LOBJS) ./src/ellipticMain.o libblas libogs libparAlmond
+ifdef PMPI_WRAP
+	PMPI_WRAP_DIR := ../../libs/PMPIWrap
+	LIBS          += -L$(PMPI_WRAP_DIR) -lPMPIWrap -lnvToolsExt
+	PMPI_WRAP_DEP  = PMPIWrap
+endif
+
+ellipticMain:$(AOBJS) $(LOBJS) ./src/ellipticMain.o libblas libogs libparAlmond $(PMPI_WRAP_DEP)
 	$(LD)  $(LDFLAGS)  -o ellipticMain ./src/ellipticMain.o $(COBJS) $(AOBJS) $(LOBJS) $(paths) $(LIBS)
 
 lib:$(AOBJS)
@@ -149,6 +155,9 @@ libblas:
 
 libparAlmond:
 	cd ../../libs/parAlmond; make -j lib; cd ../../solvers/elliptic
+
+PMPIWrap:
+	cd ../../libs/PMPIWrap make
 
 all: lib ellipticMain
 


### PR DESCRIPTION
This is only available with the elliptic solver at the moment.  To use, do, e.g.:
```
cd solvers/elliptic
make -j PMPI_WRAP=1
mpiexec -n 2 nvprof -o profile.%q{OMPI_COMM_WORLD_RANK}.prof ./ellipticMain setups/setupQuad3D.rc
```
Then, open the generated profiles with `nvvp`.