### PR TITLE
[elliptic] Take min instead of max across ranks for allNeumann flag.

### DIFF
--- a/solvers/elliptic/src/ellipticBoundarySetup.cpp
+++ b/solvers/elliptic/src/ellipticBoundarySetup.cpp
@@ -55,7 +55,7 @@ void elliptic_t::BoundarySetup(){
   o_EToB = device.malloc(mesh.Nelements*mesh.Nfaces*sizeof(int), EToB);
 
   //collect the allNeumann flags from other ranks
-  MPI_Allreduce(&localAllNeumann, &allNeumann, 1, MPI_INT, MPI_MAX, comm);
+  MPI_Allreduce(&localAllNeumann, &allNeumann, 1, MPI_INT, MPI_MIN, comm);
 
 
   //make a node-wise bc flag using the gsop (prioritize Dirichlet boundaries over Neumann)


### PR DESCRIPTION
`allNeumann` should be 1 only if it is 1 on all ranks.  If any rank sets
it to 0, then it should be 0.  That means we need a min operation, not a
max.

This closes #29.