### PR TITLE
[Core] Fix MPI aliasing issue in platform_t::DeviceConfig().

### DIFF
--- a/libs/core/platformDeviceConfig.cpp
+++ b/libs/core/platformDeviceConfig.cpp
@@ -82,7 +82,7 @@ void platform_t::DeviceConfig(){
     int namelen;
     MPI_Get_processor_name(hostname,&namelen);
 
-    MPI_Allgather(hostname , MPI_MAX_PROCESSOR_NAME, MPI_CHAR,
+    MPI_Allgather(MPI_IN_PLACE , MPI_MAX_PROCESSOR_NAME, MPI_CHAR,
                   hostnames, MPI_MAX_PROCESSOR_NAME, MPI_CHAR, MPI_COMM_WORLD);
 
     int localRank = 0;


### PR DESCRIPTION
The hostname and hostnames buffers in this code are aliased on rank 0, and
apparently not all MPI implementations are cool with that.