### PR TITLE
[Mesh][Solvers] Switch to using tensor product form to interpolate to plotting nodes for Quads and Hexes

### DIFF
--- a/include/mesh.hpp
+++ b/include/mesh.hpp
@@ -195,6 +195,8 @@ public:
 
   // plotting info for generating field vtu
   int    plotNverts=0;    // number of vertices for each plot element
+  int    plotN=0;         // degree of plot interpolation
+  int    plotNq=0;        // plotNq = plotN+1
   int    plotNp=0;        // number of plot nodes per element
   int    plotNelements=0; // number of "plot elements" per element
   int    *plotEToV;       // triangulation of plot nodes
@@ -338,6 +340,8 @@ public:
   virtual dfloat ElementCharacteristicLength(dlong e) = 0;
 
   virtual dfloat MinCharacteristicLength() = 0;
+
+  virtual void PlotInterp(const dfloat* q, dfloat* Iq, dfloat* scratch=nullptr)=0;
 
   void RecursiveSpectralBisectionPartition();
 

--- a/include/mesh/mesh2D.hpp
+++ b/include/mesh/mesh2D.hpp
@@ -66,6 +66,8 @@ public:
   void CubatureNodes();
 
   void MassMatrixKernelSetup(int Nfields);
+
+  void PlotInterp(const dfloat* q, dfloat* Iq, dfloat* scratch=nullptr);
 };
 
 class meshQuad2D: public mesh2D {
@@ -84,6 +86,8 @@ public:
   void CubatureNodes();
 
   void MassMatrixKernelSetup(int Nfields);
+
+  void PlotInterp(const dfloat* q, dfloat* Iq, dfloat* scratch=nullptr);
 };
 
 #endif

--- a/include/mesh/mesh3D.hpp
+++ b/include/mesh/mesh3D.hpp
@@ -69,6 +69,8 @@ public:
   void CubatureNodes();
 
   void MassMatrixKernelSetup(int Nfields);
+
+  void PlotInterp(const dfloat* q, dfloat* Iq, dfloat* scratch=nullptr);
 };
 
 class meshQuad3D: public mesh3D {
@@ -87,6 +89,8 @@ public:
   void CubatureNodes();
 
   void MassMatrixKernelSetup(int Nfields);
+
+  void PlotInterp(const dfloat* q, dfloat* Iq, dfloat* scratch=nullptr);
 };
 
 class meshTet3D: public mesh3D {
@@ -105,6 +109,8 @@ public:
   void CubatureNodes();
 
   void MassMatrixKernelSetup(int Nfields);
+
+  void PlotInterp(const dfloat* q, dfloat* Iq, dfloat* scratch=nullptr);
 };
 
 class meshHex3D: public mesh3D {
@@ -123,6 +129,8 @@ public:
   void CubatureNodes();
 
   void MassMatrixKernelSetup(int Nfields);
+
+  void PlotInterp(const dfloat* q, dfloat* Iq, dfloat* scratch=nullptr);
 };
 
 #endif

--- a/libs/mesh/meshPlotInterpHex3D.cpp
+++ b/libs/mesh/meshPlotInterpHex3D.cpp
@@ -1,0 +1,101 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "mesh.hpp"
+#include "mesh/mesh3D.hpp"
+
+//interpolate field to plotting nodes
+void meshHex3D::PlotInterp(const dfloat* q, dfloat* Iq, dfloat* scratch){
+
+  dfloat *IQ, *IIQ;
+
+  bool alloc_scratch=false;
+  if (scratch==nullptr) {
+    //if not provided with a scratch space, alloc our own
+    alloc_scratch=true;
+    IQ  = (dfloat *) malloc(plotNq*Nq*Nq*sizeof(dfloat));
+    IIQ = (dfloat *) malloc(plotNq*plotNq*Nq*sizeof(dfloat));
+  } else {
+    IQ  = scratch;
+    IIQ = scratch + plotNq*Nq*Nq;
+  }
+
+  //interpolate in r
+  for(int k=0;k<Nq;++k){
+    for(int j=0;j<Nq;++j){
+      for(int i=0;i<plotNq;++i){
+        dfloat qn = 0;
+
+        for(int m=0;m<Nq;++m){
+          const int qid = m + j*Nq + k*Nq*Nq;
+          qn += plotInterp[i*Nq+m]*q[qid];
+        }
+
+        const int id = i + j*plotNq + k*Nq*plotNq;
+        IQ[id] = qn;
+      }
+    }
+  }
+
+  //interpolate in s
+  for(int k=0;k<Nq;++k){
+    for(int j=0;j<plotNq;++j){
+      for(int i=0;i<plotNq;++i){
+        dfloat qn = 0;
+
+        for(int m=0;m<Nq;++m){
+          const int qid = i + m*plotNq + k*Nq*plotNq;
+          qn += plotInterp[j*Nq+m]*IQ[qid];
+        }
+
+        const int id = i + j*plotNq + k*plotNq*plotNq;
+        IIQ[id] = qn;
+      }
+    }
+  }
+
+  //interpolate in k and write
+  for(int k=0;k<plotNq;++k){
+    for(int j=0;j<plotNq;++j){
+      for(int i=0;i<plotNq;++i){
+        dfloat qn = 0;
+
+        for(int m=0;m<Nq;++m){
+          const int qid = i + j*plotNq + m*plotNq*plotNq;
+          qn += plotInterp[k*Nq+m]*IIQ[qid];
+        }
+
+        const int id = i + j*plotNq + k*plotNq*plotNq;
+        Iq[id] = qn;
+      }
+    }
+  }
+
+  //clean up
+  if (alloc_scratch) {
+    free(IQ); free(IIQ);
+  }
+}

--- a/libs/mesh/meshPlotInterpQuad2D.cpp
+++ b/libs/mesh/meshPlotInterpQuad2D.cpp
@@ -1,0 +1,78 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "mesh.hpp"
+#include "mesh/mesh2D.hpp"
+
+//interpolate field to plotting nodes
+void meshQuad2D::PlotInterp(const dfloat* q, dfloat* Iq, dfloat* scratch){
+
+  dfloat *IQ;
+
+  bool alloc_scratch=false;
+  if (scratch==nullptr) {
+    //if not provided with a scratch space, alloc our own
+    alloc_scratch=true;
+    IQ  = (dfloat *) malloc(plotNq*Nq*sizeof(dfloat));
+  } else {
+    IQ  = scratch;
+  }
+
+  //interpolate in r
+  for(int j=0;j<Nq;++j){
+    for(int i=0;i<plotNq;++i){
+      dfloat qn = 0;
+
+      for(int m=0;m<Nq;++m){
+        const int qid = m + j*Nq;
+        qn += plotInterp[i*Nq+m]*q[qid];
+      }
+
+      const int id = i + j*plotNq;
+      IQ[id] = qn;
+    }
+  }
+
+  //interpolate in s
+  for(int j=0;j<plotNq;++j){
+    for(int i=0;i<plotNq;++i){
+      dfloat qn = 0;
+
+      for(int m=0;m<Nq;++m){
+        const int qid = i + m*plotNq;
+        qn += plotInterp[j*Nq+m]*IQ[qid];
+      }
+
+      const int id = i + j*plotNq;
+      Iq[id] = qn;
+    }
+  }
+
+  //clean up
+  if (alloc_scratch) {
+    free(IQ);
+  }
+}

--- a/libs/mesh/meshPlotInterpQuad3D.cpp
+++ b/libs/mesh/meshPlotInterpQuad3D.cpp
@@ -1,0 +1,78 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "mesh.hpp"
+#include "mesh/mesh3D.hpp"
+
+//interpolate field to plotting nodes
+void meshQuad3D::PlotInterp(const dfloat* q, dfloat* Iq, dfloat* scratch){
+
+  dfloat *IQ;
+
+  bool alloc_scratch=false;
+  if (scratch==nullptr) {
+    //if not provided with a scratch space, alloc our own
+    alloc_scratch=true;
+    IQ  = (dfloat *) malloc(plotNq*Nq*sizeof(dfloat));
+  } else {
+    IQ  = scratch;
+  }
+
+  //interpolate in r
+  for(int j=0;j<Nq;++j){
+    for(int i=0;i<plotNq;++i){
+      dfloat qn = 0;
+
+      for(int m=0;m<Nq;++m){
+        const int qid = m + j*Nq;
+        qn += plotInterp[i*Nq+m]*q[qid];
+      }
+
+      const int id = i + j*plotNq;
+      IQ[id] = qn;
+    }
+  }
+
+  //interpolate in s
+  for(int j=0;j<plotNq;++j){
+    for(int i=0;i<plotNq;++i){
+      dfloat qn = 0;
+
+      for(int m=0;m<Nq;++m){
+        const int qid = i + m*plotNq;
+        qn += plotInterp[j*Nq+m]*IQ[qid];
+      }
+
+      const int id = i + j*plotNq;
+      Iq[id] = qn;
+    }
+  }
+
+  //clean up
+  if (alloc_scratch) {
+    free(IQ);
+  }
+}

--- a/libs/mesh/meshPlotInterpTet3D.cpp
+++ b/libs/mesh/meshPlotInterpTet3D.cpp
@@ -1,0 +1,42 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "mesh.hpp"
+#include "mesh/mesh3D.hpp"
+
+//interpolate field to plotting nodes
+void meshTet3D::PlotInterp(const dfloat* q, dfloat* Iq, dfloat* scratch){
+
+  //interpolate
+  for(int n=0;n<plotNp;++n){
+    dfloat qn = 0;
+
+    for(int m=0;m<Np;++m){
+      qn += plotInterp[n*Np+m]*q[m];
+    }
+    Iq[n] = qn;
+  }
+}

--- a/libs/mesh/meshPlotInterpTri2D.cpp
+++ b/libs/mesh/meshPlotInterpTri2D.cpp
@@ -1,0 +1,42 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "mesh.hpp"
+#include "mesh/mesh2D.hpp"
+
+//interpolate field to plotting nodes
+void meshTri2D::PlotInterp(const dfloat* q, dfloat* Iq, dfloat* scratch){
+
+  //interpolate
+  for(int n=0;n<plotNp;++n){
+    dfloat qn = 0;
+
+    for(int m=0;m<Np;++m){
+      qn += plotInterp[n*Np+m]*q[m];
+    }
+    Iq[n] = qn;
+  }
+}

--- a/libs/mesh/meshPlotInterpTri3D.cpp
+++ b/libs/mesh/meshPlotInterpTri3D.cpp
@@ -1,0 +1,42 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "mesh.hpp"
+#include "mesh/mesh3D.hpp"
+
+//interpolate field to plotting nodes
+void meshTri3D::PlotInterp(const dfloat* q, dfloat* Iq, dfloat* scratch){
+
+  //interpolate
+  for(int n=0;n<plotNp;++n){
+    dfloat qn = 0;
+
+    for(int m=0;m<Np;++m){
+      qn += plotInterp[n*Np+m]*q[m];
+    }
+    Iq[n] = qn;
+  }
+}

--- a/libs/mesh/meshReferenceNodesHex3D.cpp
+++ b/libs/mesh/meshReferenceNodesHex3D.cpp
@@ -60,11 +60,10 @@ void meshHex3D::ReferenceNodes(int N_){
   // D matrix
   D = (dfloat *) malloc(Nq*Nq*sizeof(dfloat));
   Dmatrix1D(N, Nq, gllz, Nq, gllz, D);
-  free(gllz);
 
   /* Plotting data */
-  int plotN = N_ + 3; //enriched interpolation space for plotting
-  int plotNq = plotN + 1;
+  plotN = N_ + 3; //enriched interpolation space for plotting
+  plotNq = plotN + 1;
   plotNp = plotNq*plotNq*plotNq;
 
   /* Plotting nodes */
@@ -78,7 +77,13 @@ void meshHex3D::ReferenceNodes(int N_){
   plotEToV = (int*) malloc(plotNelements*plotNverts*sizeof(int));
   EquispacedEToVHex3D(plotN, plotEToV);
 
-  plotInterp = (dfloat *) malloc(Np*plotNp*sizeof(dfloat));
-  InterpolationMatrixHex3D(N, Np, r, s, t, plotNp, plotR, plotS, plotT, plotInterp);
+  dfloat *plot1D = (dfloat *) malloc(plotNq*sizeof(dfloat));
+  EquispacedNodes1D(plotN, plot1D);
+
+  plotInterp = (dfloat *) malloc(Nq*plotNq*sizeof(dfloat));
+  InterpolationMatrix1D(N, Nq, gllz, plotNq, plot1D, plotInterp);
+
+  free(gllz);
+  free(plot1D);
 }
 

--- a/libs/mesh/meshReferenceNodesQuad2D.cpp
+++ b/libs/mesh/meshReferenceNodesQuad2D.cpp
@@ -66,11 +66,10 @@ void meshQuad2D::ReferenceNodes(int N_){
   // D matrix
   D = (dfloat *) malloc(Nq*Nq*sizeof(dfloat));
   Dmatrix1D(N, Nq, gllz, Nq, gllz, D);
-  free(gllz);
 
   /* Plotting data */
-  int plotN = N_ + 3; //enriched interpolation space for plotting
-  int plotNq = plotN + 1;
+  plotN = N_ + 3; //enriched interpolation space for plotting
+  plotNq = plotN + 1;
   plotNp = plotNq*plotNq;
 
   /* Plotting nodes */
@@ -83,7 +82,13 @@ void meshQuad2D::ReferenceNodes(int N_){
   plotEToV = (int*) malloc(plotNelements*plotNverts*sizeof(int));
   EquispacedEToVQuad2D(plotN, plotEToV);
 
-  plotInterp = (dfloat *) malloc(Np*plotNp*sizeof(dfloat));
-  InterpolationMatrixQuad2D(N, Np, r, s, plotNp, plotR, plotS, plotInterp);
+  dfloat *plot1D = (dfloat *) malloc(plotNq*sizeof(dfloat));
+  EquispacedNodes1D(plotN, plot1D);
+
+  plotInterp = (dfloat *) malloc(Nq*plotNq*sizeof(dfloat));
+  InterpolationMatrix1D(N, Nq, gllz, plotNq, plot1D, plotInterp);
+
+  free(gllz);
+  free(plot1D);
 }
 

--- a/libs/mesh/meshReferenceNodesTet3D.cpp
+++ b/libs/mesh/meshReferenceNodesTet3D.cpp
@@ -79,7 +79,7 @@ void meshTet3D::ReferenceNodes(int N_){
   SmatrixTet3D(N, Dr, Ds, Dt, MM, Srr, Srs, Srt, Sss, Sst, Stt);
 
   /* Plotting data */
-  int plotN = N + 3; //enriched interpolation space for plotting
+  plotN = N + 3; //enriched interpolation space for plotting
   plotNp = (plotN+1)*(plotN+2)*(plotN+3)/6;
 
   /* Plotting nodes */

--- a/libs/mesh/meshReferenceNodesTri2D.cpp
+++ b/libs/mesh/meshReferenceNodesTri2D.cpp
@@ -81,7 +81,7 @@ void meshTri2D::ReferenceNodes(int N_){
   SmatrixTri2D(N, Dr, Ds, MM, Srr, Srs, Sss);
 
   /* Plotting data */
-  int plotN = N + 3; //enriched interpolation space for plotting
+  plotN = N + 3; //enriched interpolation space for plotting
   plotNp = (plotN+1)*(plotN+2)/2;
 
   /* Plotting nodes */

--- a/solvers/advection/src/advectionPlotFields.cpp
+++ b/solvers/advection/src/advectionPlotFields.cpp
@@ -43,42 +43,47 @@ void advection_t::PlotFields(dfloat* Q, char *fileName){
   fprintf(fp, "      <Points>\n");
   fprintf(fp, "        <DataArray type=\"Float32\" NumberOfComponents=\"3\" Format=\"ascii\">\n");
 
+  //scratch space for interpolation
+  size_t NscratchBytes = mymax(mesh.Np, mesh.plotNp)*sizeof(dfloat);
+  dfloat* scratch = (dfloat *) malloc(2*NscratchBytes);
+
+  dfloat* Ix = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iy = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iz = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+
   // compute plot node coordinates on the fly
   for(dlong e=0;e<mesh.Nelements;++e){
+    mesh.PlotInterp(mesh.x + e*mesh.Np, Ix, scratch);
+    mesh.PlotInterp(mesh.y + e*mesh.Np, Iy, scratch);
+    mesh.PlotInterp(mesh.z + e*mesh.Np, Iz, scratch);
+
     for(int n=0;n<mesh.plotNp;++n){
-      dfloat plotxn = 0, plotyn = 0, plotzn = 0;
-
-      for(int m=0;m<mesh.Np;++m){
-        plotxn += mesh.plotInterp[n*mesh.Np+m]*mesh.x[m+e*mesh.Np];
-        plotyn += mesh.plotInterp[n*mesh.Np+m]*mesh.y[m+e*mesh.Np];
-        plotzn += mesh.plotInterp[n*mesh.Np+m]*mesh.z[m+e*mesh.Np];
-      }
-
       fprintf(fp, "       ");
-      fprintf(fp, "%g %g %g\n", plotxn,plotyn,plotzn);
+      fprintf(fp, "%g %g %g\n", Ix[n],Iy[n],Iz[n]);
     }
   }
   fprintf(fp, "        </DataArray>\n");
   fprintf(fp, "      </Points>\n");
 
+  free(Ix); free(Iy); free(Iz);
+
+  dfloat* Ip = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
 
   // write out field
   fprintf(fp, "      <PointData Scalars=\"scalars\">\n");
   fprintf(fp, "        <DataArray type=\"Float32\" Name=\"Field\" Format=\"ascii\">\n");
   for(dlong e=0;e<mesh.Nelements;++e){
-    for(int n=0;n<mesh.plotNp;++n){
-      dfloat plotpn = 0;
-      for(int m=0;m<mesh.Np;++m){
-        dfloat pm = Q[e*mesh.Np+m];
-        plotpn += mesh.plotInterp[n*mesh.Np+m]*pm;
-      }
+    mesh.PlotInterp(Q + e*mesh.Np, Ip, scratch);
 
+    for(int n=0;n<mesh.plotNp;++n){
       fprintf(fp, "       ");
-      fprintf(fp, "%g\n", plotpn);
+      fprintf(fp, "%g\n", Ip[n]);
     }
   }
   fprintf(fp, "       </DataArray>\n");
   fprintf(fp, "     </PointData>\n");
+
+  free(Ip);
 
   fprintf(fp, "    <Cells>\n");
   fprintf(fp, "      <DataArray type=\"Int32\" Name=\"connectivity\" Format=\"ascii\">\n");
@@ -121,4 +126,5 @@ void advection_t::PlotFields(dfloat* Q, char *fileName){
   fprintf(fp, "</VTKFile>\n");
   fclose(fp);
 
+  free(scratch);
 }

--- a/solvers/bns/src/bnsPlotFields.cpp
+++ b/solvers/bns/src/bnsPlotFields.cpp
@@ -43,39 +43,49 @@ void bns_t::PlotFields(dfloat* Q, dfloat *V, char *fileName){
   fprintf(fp, "      <Points>\n");
   fprintf(fp, "        <DataArray type=\"Float32\" NumberOfComponents=\"3\" Format=\"ascii\">\n");
 
+  //scratch space for interpolation
+  size_t NscratchBytes = mymax(mesh.Np, mesh.plotNp)*sizeof(dfloat);
+  dfloat* scratch = (dfloat *) malloc(2*NscratchBytes);
+
+  dfloat* Ix = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iy = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iz = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+
   // compute plot node coordinates on the fly
   for(dlong e=0;e<mesh.Nelements;++e){
+    mesh.PlotInterp(mesh.x + e*mesh.Np, Ix, scratch);
+    mesh.PlotInterp(mesh.y + e*mesh.Np, Iy, scratch);
+    mesh.PlotInterp(mesh.z + e*mesh.Np, Iz, scratch);
+
     for(int n=0;n<mesh.plotNp;++n){
-      dfloat plotxn = 0, plotyn = 0, plotzn = 0;
-
-      for(int m=0;m<mesh.Np;++m){
-        plotxn += mesh.plotInterp[n*mesh.Np+m]*mesh.x[m+e*mesh.Np];
-        plotyn += mesh.plotInterp[n*mesh.Np+m]*mesh.y[m+e*mesh.Np];
-        plotzn += mesh.plotInterp[n*mesh.Np+m]*mesh.z[m+e*mesh.Np];
-      }
-
       fprintf(fp, "       ");
-      fprintf(fp, "%g %g %g\n", plotxn,plotyn,plotzn);
+      fprintf(fp, "%g %g %g\n", Ix[n],Iy[n],Iz[n]);
     }
   }
   fprintf(fp, "        </DataArray>\n");
   fprintf(fp, "      </Points>\n");
 
+  free(Ix); free(Iy); free(Iz);
+
+  dfloat* u = (dfloat *) malloc(mesh.Np*sizeof(dfloat));
+  dfloat* v = (dfloat *) malloc(mesh.Np*sizeof(dfloat));
+  dfloat* w = (dfloat *) malloc(mesh.Np*sizeof(dfloat));
+
+  dfloat* Ip = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iu = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iv = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iw = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
 
   if (Q!=NULL) {
     // write out density
     fprintf(fp, "      <PointData Scalars=\"scalars\">\n");
     fprintf(fp, "        <DataArray type=\"Float32\" Name=\"Density\" Format=\"ascii\">\n");
     for(dlong e=0;e<mesh.Nelements;++e){
-      for(int n=0;n<mesh.plotNp;++n){
-        dfloat plotpn = 0;
-        for(int m=0;m<mesh.Np;++m){
-          dfloat pm = Q[e*mesh.Np*Nfields+m];
-          plotpn += mesh.plotInterp[n*mesh.Np+m]*pm;
-        }
+      mesh.PlotInterp(Q + e*mesh.Np*Nfields, Ip, scratch);
 
+      for(int n=0;n<mesh.plotNp;++n){
         fprintf(fp, "       ");
-        fprintf(fp, "%g\n", plotpn);
+        fprintf(fp, "%g\n", Ip[n]);
       }
     }
     fprintf(fp, "       </DataArray>\n");
@@ -83,29 +93,26 @@ void bns_t::PlotFields(dfloat* Q, dfloat *V, char *fileName){
     // write out velocity
     fprintf(fp, "        <DataArray type=\"Float32\" Name=\"Velocity\" NumberOfComponents=\"%d\" Format=\"ascii\">\n", mesh.dim);
     for(dlong e=0;e<mesh.Nelements;++e){
+      for(int n=0;n<mesh.Np;++n){
+        const dfloat rm = Q[e*mesh.Np*Nfields+n];
+        u[n] = c*Q[e*mesh.Np*Nfields+n+mesh.Np*1]/rm;
+        v[n] = c*Q[e*mesh.Np*Nfields+n+mesh.Np*2]/rm;
+        if(mesh.dim==3)
+          w[n] = c*Q[e*mesh.Np*Nfields+n+mesh.Np*3]/rm;
+      }
+
+      mesh.PlotInterp(u, Iu, scratch);
+      mesh.PlotInterp(v, Iv, scratch);
+      if(mesh.dim==3)
+        mesh.PlotInterp(w, Iw, scratch);
+
       for(int n=0;n<mesh.plotNp;++n){
-        dfloat plotun = 0, plotvn = 0, plotwn = 0;
-        for(int m=0;m<mesh.Np;++m){
-          dfloat rm = Q[e*mesh.Np*Nfields+m+mesh.Np*0];
-          dfloat um = c*Q[e*mesh.Np*Nfields+m+mesh.Np*1]/rm;
-          dfloat vm = c*Q[e*mesh.Np*Nfields+m+mesh.Np*2]/rm;
-
-          plotun += mesh.plotInterp[n*mesh.Np+m]*um;
-          plotvn += mesh.plotInterp[n*mesh.Np+m]*vm;
-
-          if(mesh.dim==3){
-            dfloat wm = c*Q[e*mesh.Np*Nfields+m+mesh.Np*3]/rm;
-
-            plotwn += mesh.plotInterp[n*mesh.Np+m]*wm;
-          }
-        }
-
         fprintf(fp, "       ");
         fprintf(fp, "       ");
         if (mesh.dim==2)
-          fprintf(fp, "%g %g\n", plotun, plotvn);
+          fprintf(fp, "%g %g\n", Iu[n], Iv[n]);
         else
-          fprintf(fp, "%g %g %g\n", plotun, plotvn, plotwn);
+          fprintf(fp, "%g %g %g\n", Iu[n], Iv[n], Iw[n]);
       }
     }
     fprintf(fp, "       </DataArray>\n");
@@ -113,15 +120,11 @@ void bns_t::PlotFields(dfloat* Q, dfloat *V, char *fileName){
     // write out pressure
     fprintf(fp, "        <DataArray type=\"Float32\" Name=\"Pressure\" Format=\"ascii\">\n");
     for(dlong e=0;e<mesh.Nelements;++e){
-      for(int n=0;n<mesh.plotNp;++n){
-        dfloat plotpn = 0;
-        for(int m=0;m<mesh.Np;++m){
-          dfloat pm = RT*Q[e*mesh.Np*Nfields+m+mesh.Np*0];
-          plotpn += mesh.plotInterp[n*mesh.Np+m]*pm;
-        }
+      mesh.PlotInterp(Q + e*mesh.Np*Nfields, Ip, scratch);
 
+      for(int n=0;n<mesh.plotNp;++n){
         fprintf(fp, "       ");
-        fprintf(fp, "%g\n", plotpn);
+        fprintf(fp, "%g\n", RT*Ip[n]);
       }
     }
     fprintf(fp, "       </DataArray>\n");
@@ -132,42 +135,33 @@ void bns_t::PlotFields(dfloat* Q, dfloat *V, char *fileName){
     if(mesh.dim==2){
       fprintf(fp, "        <DataArray type=\"Float32\" Name=\"Vorticity\" Format=\"ascii\">\n");
       for(dlong e=0;e<mesh.Nelements;++e){
-        for(int n=0;n<mesh.plotNp;++n){
-          dfloat plotVort = 0;
-          for(int m=0;m<mesh.Np;++m){
-            dlong id = m+e*mesh.Np;
-            dfloat vort = V[id];
-            plotVort += mesh.plotInterp[n*mesh.Np+m]*vort;
-          }
+        mesh.PlotInterp(V + e*mesh.Np, Ip, scratch);
 
+        for(int n=0;n<mesh.plotNp;++n){
           fprintf(fp, "       ");
-          fprintf(fp, "%g\n", plotVort);
+          fprintf(fp, "%g\n", Ip[n]);
         }
       }
     } else {
       fprintf(fp, "        <DataArray type=\"Float32\" Name=\"Vorticity\" NumberOfComponents=\"3\" Format=\"ascii\">\n");
       for(dlong e=0;e<mesh.Nelements;++e){
-        for(int n=0;n<mesh.plotNp;++n){
-          dfloat plotVortx = 0, plotVorty = 0, plotVortz = 0;
-          for(int m=0;m<mesh.Np;++m){
-            dlong id = m+e*mesh.Np*3;
-            dfloat vortx = V[id+mesh.Np*0];
-            dfloat vorty = V[id+mesh.Np*1];
-            dfloat vortz = V[id+mesh.Np*2];
-            plotVortx += mesh.plotInterp[n*mesh.Np+m]*vortx;
-            plotVorty += mesh.plotInterp[n*mesh.Np+m]*vorty;
-            plotVortz += mesh.plotInterp[n*mesh.Np+m]*vortz;
-          }
+        mesh.PlotInterp(V + 0*mesh.Np + e*mesh.Np*3, Iu, scratch);
+        mesh.PlotInterp(V + 1*mesh.Np + e*mesh.Np*3, Iv, scratch);
+        mesh.PlotInterp(V + 2*mesh.Np + e*mesh.Np*3, Iw, scratch);
 
+        for(int n=0;n<mesh.plotNp;++n){
           fprintf(fp, "       ");
-          fprintf(fp, "%g %g %g\n", plotVortx, plotVorty, plotVortz);
+          fprintf(fp, "       ");
+          fprintf(fp, "%g %g %g\n", Iu[n], Iv[n], Iw[n]);
         }
       }
     }
     fprintf(fp, "       </DataArray>\n");
   }
-
   fprintf(fp, "     </PointData>\n");
+
+  free(u); free(v); free(w);
+  free(Ip); free(Iu); free(Iv); free(Iw);
 
   fprintf(fp, "    <Cells>\n");
   fprintf(fp, "      <DataArray type=\"Int32\" Name=\"connectivity\" Format=\"ascii\">\n");
@@ -210,4 +204,5 @@ void bns_t::PlotFields(dfloat* Q, dfloat *V, char *fileName){
   fprintf(fp, "</VTKFile>\n");
   fclose(fp);
 
+  free(scratch);
 }

--- a/solvers/cns/src/cnsPlotFields.cpp
+++ b/solvers/cns/src/cnsPlotFields.cpp
@@ -43,39 +43,50 @@ void cns_t::PlotFields(dfloat* Q, dfloat *V, char *fileName){
   fprintf(fp, "      <Points>\n");
   fprintf(fp, "        <DataArray type=\"Float32\" NumberOfComponents=\"3\" Format=\"ascii\">\n");
 
+  //scratch space for interpolation
+  size_t NscratchBytes = mymax(mesh.Np, mesh.plotNp)*sizeof(dfloat);
+  dfloat* scratch = (dfloat *) malloc(2*NscratchBytes);
+
+  dfloat* Ix = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iy = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iz = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+
   // compute plot node coordinates on the fly
   for(dlong e=0;e<mesh.Nelements;++e){
+    mesh.PlotInterp(mesh.x + e*mesh.Np, Ix, scratch);
+    mesh.PlotInterp(mesh.y + e*mesh.Np, Iy, scratch);
+    mesh.PlotInterp(mesh.z + e*mesh.Np, Iz, scratch);
+
     for(int n=0;n<mesh.plotNp;++n){
-      dfloat plotxn = 0, plotyn = 0, plotzn = 0;
-
-      for(int m=0;m<mesh.Np;++m){
-        plotxn += mesh.plotInterp[n*mesh.Np+m]*mesh.x[m+e*mesh.Np];
-        plotyn += mesh.plotInterp[n*mesh.Np+m]*mesh.y[m+e*mesh.Np];
-        plotzn += mesh.plotInterp[n*mesh.Np+m]*mesh.z[m+e*mesh.Np];
-      }
-
       fprintf(fp, "       ");
-      fprintf(fp, "%g %g %g\n", plotxn,plotyn,plotzn);
+      fprintf(fp, "%g %g %g\n", Ix[n],Iy[n],Iz[n]);
     }
   }
   fprintf(fp, "        </DataArray>\n");
   fprintf(fp, "      </Points>\n");
 
+  free(Ix); free(Iy); free(Iz);
+
+  dfloat* p = (dfloat *) malloc(mesh.Np*sizeof(dfloat));
+  dfloat* u = (dfloat *) malloc(mesh.Np*sizeof(dfloat));
+  dfloat* v = (dfloat *) malloc(mesh.Np*sizeof(dfloat));
+  dfloat* w = (dfloat *) malloc(mesh.Np*sizeof(dfloat));
+
+  dfloat* Ip = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iu = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iv = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iw = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
 
   if (Q!=NULL) {
     // write out density
     fprintf(fp, "      <PointData Scalars=\"scalars\">\n");
     fprintf(fp, "        <DataArray type=\"Float32\" Name=\"Density\" Format=\"ascii\">\n");
     for(dlong e=0;e<mesh.Nelements;++e){
-      for(int n=0;n<mesh.plotNp;++n){
-        dfloat plotpn = 0;
-        for(int m=0;m<mesh.Np;++m){
-          dfloat pm = Q[e*mesh.Np*Nfields+m];
-          plotpn += mesh.plotInterp[n*mesh.Np+m]*pm;
-        }
+      mesh.PlotInterp(Q + e*mesh.Np*Nfields, Ip, scratch);
 
+      for(int n=0;n<mesh.plotNp;++n){
         fprintf(fp, "       ");
-        fprintf(fp, "%g\n", plotpn);
+        fprintf(fp, "%g\n", Ip[n]);
       }
     }
     fprintf(fp, "       </DataArray>\n");
@@ -83,29 +94,26 @@ void cns_t::PlotFields(dfloat* Q, dfloat *V, char *fileName){
     // write out velocity
     fprintf(fp, "        <DataArray type=\"Float32\" Name=\"Velocity\" NumberOfComponents=\"%d\" Format=\"ascii\">\n", mesh.dim);
     for(dlong e=0;e<mesh.Nelements;++e){
+      for(int n=0;n<mesh.Np;++n){
+        const dfloat rm = Q[e*mesh.Np*Nfields+n];
+        u[n] = Q[e*mesh.Np*Nfields+n+mesh.Np*1]/rm;
+        v[n] = Q[e*mesh.Np*Nfields+n+mesh.Np*2]/rm;
+        if(mesh.dim==3)
+          w[n] = Q[e*mesh.Np*Nfields+n+mesh.Np*3]/rm;
+      }
+
+      mesh.PlotInterp(u, Iu, scratch);
+      mesh.PlotInterp(v, Iv, scratch);
+      if(mesh.dim==3)
+        mesh.PlotInterp(w, Iw, scratch);
+
       for(int n=0;n<mesh.plotNp;++n){
-        dfloat plotun = 0, plotvn = 0, plotwn = 0;
-        for(int m=0;m<mesh.Np;++m){
-          dfloat rm = Q[e*mesh.Np*Nfields+m+mesh.Np*0];
-          dfloat um = Q[e*mesh.Np*Nfields+m+mesh.Np*1]/rm;
-          dfloat vm = Q[e*mesh.Np*Nfields+m+mesh.Np*2]/rm;
-
-          plotun += mesh.plotInterp[n*mesh.Np+m]*um;
-          plotvn += mesh.plotInterp[n*mesh.Np+m]*vm;
-
-          if(mesh.dim==3){
-            dfloat wm = Q[e*mesh.Np*Nfields+m+mesh.Np*3]/rm;
-
-            plotwn += mesh.plotInterp[n*mesh.Np+m]*wm;
-          }
-        }
-
         fprintf(fp, "       ");
         fprintf(fp, "       ");
         if (mesh.dim==2)
-          fprintf(fp, "%g %g\n", plotun, plotvn);
+          fprintf(fp, "%g %g\n", Iu[n], Iv[n]);
         else
-          fprintf(fp, "%g %g %g\n", plotun, plotvn, plotwn);
+          fprintf(fp, "%g %g %g\n", Iu[n], Iv[n], Iw[n]);
       }
     }
     fprintf(fp, "       </DataArray>\n");
@@ -115,21 +123,21 @@ void cns_t::PlotFields(dfloat* Q, dfloat *V, char *fileName){
       // write out pressure
       fprintf(fp, "        <DataArray type=\"Float32\" Name=\"Pressure\" Format=\"ascii\">\n");
       for(dlong e=0;e<mesh.Nelements;++e){
+        for(int n=0;n<mesh.Np;++n){
+          const dfloat rm = Q[e*mesh.Np*Nfields+n];
+          const dfloat um = Q[e*mesh.Np*Nfields+n+mesh.Np*1]/rm;
+          const dfloat vm = Q[e*mesh.Np*Nfields+n+mesh.Np*2]/rm;
+          const dfloat wm = (mesh.dim==3) ? Q[e*mesh.Np*Nfields+n+mesh.Np*3]/rm : 0.0;
+          const dfloat em = Q[e*mesh.Np*Nfields+n+mesh.Np*eID];
+
+          p[n] = (gamma-1)*(em-0.5*rm*(um*um+vm*vm+wm*wm));
+        }
+
+        mesh.PlotInterp(p, Ip, scratch);
+
         for(int n=0;n<mesh.plotNp;++n){
-          dfloat plotpn = 0;
-          for(int m=0;m<mesh.Np;++m){
-            dfloat rm = Q[e*mesh.Np*Nfields+m+mesh.Np*0];
-            dfloat um = Q[e*mesh.Np*Nfields+m+mesh.Np*1]/rm;
-            dfloat vm = Q[e*mesh.Np*Nfields+m+mesh.Np*2]/rm;
-            dfloat wm = (mesh.dim==3) ? Q[e*mesh.Np*Nfields+m+mesh.Np*3]/rm : 0.0;
-            dfloat em = Q[e*mesh.Np*Nfields+m+mesh.Np*eID];
-
-            dfloat pm = (gamma-1)*(em-0.5*rm*(um*um+vm*vm+wm*wm));
-            plotpn += mesh.plotInterp[n*mesh.Np+m]*pm;
-          }
-
           fprintf(fp, "       ");
-          fprintf(fp, "%g\n", plotpn);
+          fprintf(fp, "%g\n", Ip[n]);
         }
       }
       fprintf(fp, "       </DataArray>\n");
@@ -141,35 +149,24 @@ void cns_t::PlotFields(dfloat* Q, dfloat *V, char *fileName){
     if(mesh.dim==2){
       fprintf(fp, "        <DataArray type=\"Float32\" Name=\"Vorticity\" Format=\"ascii\">\n");
       for(dlong e=0;e<mesh.Nelements;++e){
-        for(int n=0;n<mesh.plotNp;++n){
-          dfloat plotVort = 0;
-          for(int m=0;m<mesh.Np;++m){
-            dlong id = m+e*mesh.Np;
-            dfloat vort = V[id];
-            plotVort += mesh.plotInterp[n*mesh.Np+m]*vort;
-          }
+        mesh.PlotInterp(V + e*mesh.Np, Ip, scratch);
 
+        for(int n=0;n<mesh.plotNp;++n){
           fprintf(fp, "       ");
-          fprintf(fp, "%g\n", plotVort);
+          fprintf(fp, "%g\n", Ip[n]);
         }
       }
     } else {
       fprintf(fp, "        <DataArray type=\"Float32\" Name=\"Vorticity\" NumberOfComponents=\"3\" Format=\"ascii\">\n");
       for(dlong e=0;e<mesh.Nelements;++e){
-        for(int n=0;n<mesh.plotNp;++n){
-          dfloat plotVortx = 0, plotVorty = 0, plotVortz = 0;
-          for(int m=0;m<mesh.Np;++m){
-            dlong id = m+e*mesh.Np*3;
-            dfloat vortx = V[id+mesh.Np*0];
-            dfloat vorty = V[id+mesh.Np*1];
-            dfloat vortz = V[id+mesh.Np*2];
-            plotVortx += mesh.plotInterp[n*mesh.Np+m]*vortx;
-            plotVorty += mesh.plotInterp[n*mesh.Np+m]*vorty;
-            plotVortz += mesh.plotInterp[n*mesh.Np+m]*vortz;
-          }
+        mesh.PlotInterp(V + 0*mesh.Np + e*mesh.Np*3, Iu, scratch);
+        mesh.PlotInterp(V + 1*mesh.Np + e*mesh.Np*3, Iv, scratch);
+        mesh.PlotInterp(V + 2*mesh.Np + e*mesh.Np*3, Iw, scratch);
 
+        for(int n=0;n<mesh.plotNp;++n){
           fprintf(fp, "       ");
-          fprintf(fp, "%g %g %g\n", plotVortx, plotVorty, plotVortz);
+          fprintf(fp, "       ");
+          fprintf(fp, "%g %g %g\n", Iu[n], Iv[n], Iw[n]);
         }
       }
     }
@@ -177,6 +174,9 @@ void cns_t::PlotFields(dfloat* Q, dfloat *V, char *fileName){
   }
 
   fprintf(fp, "     </PointData>\n");
+
+  free(p); free(u); free(v); free(w);
+  free(Ip); free(Iu); free(Iv); free(Iw);
 
   fprintf(fp, "    <Cells>\n");
   fprintf(fp, "      <DataArray type=\"Int32\" Name=\"connectivity\" Format=\"ascii\">\n");
@@ -219,4 +219,5 @@ void cns_t::PlotFields(dfloat* Q, dfloat *V, char *fileName){
   fprintf(fp, "</VTKFile>\n");
   fclose(fp);
 
+  free(scratch);
 }

--- a/solvers/fokkerPlanck/src/fpePlotFields.cpp
+++ b/solvers/fokkerPlanck/src/fpePlotFields.cpp
@@ -43,42 +43,47 @@ void fpe_t::PlotFields(dfloat* Q, char *fileName){
   fprintf(fp, "      <Points>\n");
   fprintf(fp, "        <DataArray type=\"Float32\" NumberOfComponents=\"3\" Format=\"ascii\">\n");
 
+  //scratch space for interpolation
+  size_t NscratchBytes = mymax(mesh.Np, mesh.plotNp)*sizeof(dfloat);
+  dfloat* scratch = (dfloat *) malloc(2*NscratchBytes);
+
+  dfloat* Ix = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iy = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iz = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+
   // compute plot node coordinates on the fly
   for(dlong e=0;e<mesh.Nelements;++e){
+    mesh.PlotInterp(mesh.x + e*mesh.Np, Ix, scratch);
+    mesh.PlotInterp(mesh.y + e*mesh.Np, Iy, scratch);
+    mesh.PlotInterp(mesh.z + e*mesh.Np, Iz, scratch);
+
     for(int n=0;n<mesh.plotNp;++n){
-      dfloat plotxn = 0, plotyn = 0, plotzn = 0;
-
-      for(int m=0;m<mesh.Np;++m){
-        plotxn += mesh.plotInterp[n*mesh.Np+m]*mesh.x[m+e*mesh.Np];
-        plotyn += mesh.plotInterp[n*mesh.Np+m]*mesh.y[m+e*mesh.Np];
-        plotzn += mesh.plotInterp[n*mesh.Np+m]*mesh.z[m+e*mesh.Np];
-      }
-
       fprintf(fp, "       ");
-      fprintf(fp, "%g %g %g\n", plotxn,plotyn,plotzn);
+      fprintf(fp, "%g %g %g\n", Ix[n],Iy[n],Iz[n]);
     }
   }
   fprintf(fp, "        </DataArray>\n");
   fprintf(fp, "      </Points>\n");
 
+  free(Ix); free(Iy); free(Iz);
+
+  dfloat* Ip = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
 
   // write out field
   fprintf(fp, "      <PointData Scalars=\"scalars\">\n");
   fprintf(fp, "        <DataArray type=\"Float32\" Name=\"Field\" Format=\"ascii\">\n");
   for(dlong e=0;e<mesh.Nelements;++e){
-    for(int n=0;n<mesh.plotNp;++n){
-      dfloat plotpn = 0;
-      for(int m=0;m<mesh.Np;++m){
-        dfloat pm = Q[e*mesh.Np+m];
-        plotpn += mesh.plotInterp[n*mesh.Np+m]*pm;
-      }
+    mesh.PlotInterp(Q + e*mesh.Np, Ip, scratch);
 
+    for(int n=0;n<mesh.plotNp;++n){
       fprintf(fp, "       ");
-      fprintf(fp, "%g\n", plotpn);
+      fprintf(fp, "%g\n", Ip[n]);
     }
   }
   fprintf(fp, "       </DataArray>\n");
   fprintf(fp, "     </PointData>\n");
+
+  free(Ip);
 
   fprintf(fp, "    <Cells>\n");
   fprintf(fp, "      <DataArray type=\"Int32\" Name=\"connectivity\" Format=\"ascii\">\n");
@@ -121,4 +126,5 @@ void fpe_t::PlotFields(dfloat* Q, char *fileName){
   fprintf(fp, "</VTKFile>\n");
   fclose(fp);
 
+  free(scratch);
 }

--- a/solvers/gradient/src/gradientPlotFields.cpp
+++ b/solvers/gradient/src/gradientPlotFields.cpp
@@ -45,38 +45,44 @@ void gradient_t::PlotFields(){
   fprintf(fp, "      <Points>\n");
   fprintf(fp, "        <DataArray type=\"Float32\" NumberOfComponents=\"3\" Format=\"ascii\">\n");
 
+  //scratch space for interpolation
+  size_t NscratchBytes = mymax(mesh.Np, mesh.plotNp)*sizeof(dfloat);
+  dfloat* scratch = (dfloat *) malloc(2*NscratchBytes);
+
+  dfloat* Ix = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iy = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iz = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+
   // compute plot node coordinates on the fly
   for(dlong e=0;e<mesh.Nelements;++e){
+    mesh.PlotInterp(mesh.x + e*mesh.Np, Ix, scratch);
+    mesh.PlotInterp(mesh.y + e*mesh.Np, Iy, scratch);
+    mesh.PlotInterp(mesh.z + e*mesh.Np, Iz, scratch);
+
     for(int n=0;n<mesh.plotNp;++n){
-      dfloat plotxn = 0, plotyn = 0, plotzn = 0;
-
-      for(int m=0;m<mesh.Np;++m){
-        plotxn += mesh.plotInterp[n*mesh.Np+m]*mesh.x[m+e*mesh.Np];
-        plotyn += mesh.plotInterp[n*mesh.Np+m]*mesh.y[m+e*mesh.Np];
-        plotzn += mesh.plotInterp[n*mesh.Np+m]*mesh.z[m+e*mesh.Np];
-      }
-
       fprintf(fp, "       ");
-      fprintf(fp, "%g %g %g\n", plotxn,plotyn,plotzn);
+      fprintf(fp, "%g %g %g\n", Ix[n],Iy[n],Iz[n]);
     }
   }
   fprintf(fp, "        </DataArray>\n");
   fprintf(fp, "      </Points>\n");
 
+  free(Ix); free(Iy); free(Iz);
+
+  dfloat* Iq = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iu = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iv = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
+  dfloat* Iw = (dfloat *) malloc(mesh.plotNp*sizeof(dfloat));
 
   // write out q
   fprintf(fp, "      <PointData Scalars=\"scalars\">\n");
   fprintf(fp, "        <DataArray type=\"Float32\" Name=\"q\" Format=\"ascii\">\n");
   for(dlong e=0;e<mesh.Nelements;++e){
-    for(int n=0;n<mesh.plotNp;++n){
-      dfloat plotqn = 0;
-      for(int m=0;m<mesh.Np;++m){
-        dfloat qm = q[e*mesh.Np+m];
-        plotqn += mesh.plotInterp[n*mesh.Np+m]*qm;
-      }
+    mesh.PlotInterp(q + e*mesh.Np, Iq, scratch);
 
+    for(int n=0;n<mesh.plotNp;++n){
       fprintf(fp, "       ");
-      fprintf(fp, "%g\n", plotqn);
+      fprintf(fp, "%g\n", Iq[n]);
     }
   }
   fprintf(fp, "       </DataArray>\n");
@@ -84,31 +90,24 @@ void gradient_t::PlotFields(){
   // write out gradq
   fprintf(fp, "        <DataArray type=\"Float32\" Name=\"Gradient\" NumberOfComponents=\"%d\" Format=\"ascii\">\n", Nfields);
   for(dlong e=0;e<mesh.Nelements;++e){
+    mesh.PlotInterp(gradq + 0*mesh.Np + e*mesh.Np*Nfields, Iu, scratch);
+    mesh.PlotInterp(gradq + 1*mesh.Np + e*mesh.Np*Nfields, Iv, scratch);
+    if(mesh.dim==3)
+      mesh.PlotInterp(gradq + 2*mesh.Np + e*mesh.Np*Nfields, Iw, scratch);
+
     for(int n=0;n<mesh.plotNp;++n){
-      dfloat plotun = 0, plotvn = 0, plotwn = 0;
-      for(int m=0;m<mesh.Np;++m){
-        dfloat um = gradq[e*mesh.Np*Nfields+m+mesh.Np*0];
-        dfloat vm = gradq[e*mesh.Np*Nfields+m+mesh.Np*1];
-
-        plotun += mesh.plotInterp[n*mesh.Np+m]*um;
-        plotvn += mesh.plotInterp[n*mesh.Np+m]*vm;
-
-        if(mesh.dim==3){
-          dfloat wm = gradq[e*mesh.Np*Nfields+m+mesh.Np*2];
-          plotwn += mesh.plotInterp[n*mesh.Np+m]*wm;
-        }
-      }
-
+      fprintf(fp, "       ");
       fprintf(fp, "       ");
       if (mesh.dim==2)
-        fprintf(fp, "%g %g\n", plotun, plotvn);
+        fprintf(fp, "%g %g\n", Iu[n], Iv[n]);
       else
-        fprintf(fp, "%g %g %g\n", plotun, plotvn, plotwn);
+        fprintf(fp, "%g %g %g\n", Iu[n], Iv[n], Iw[n]);
     }
   }
   fprintf(fp, "       </DataArray>\n");
-
   fprintf(fp, "     </PointData>\n");
+
+  free(Iq); free(Iu); free(Iv); free(Iw);
 
   fprintf(fp, "    <Cells>\n");
   fprintf(fp, "      <DataArray type=\"Int32\" Name=\"connectivity\" Format=\"ascii\">\n");
@@ -151,4 +150,5 @@ void gradient_t::PlotFields(){
   fprintf(fp, "</VTKFile>\n");
   fclose(fp);
 
+  free(scratch);
 }


### PR DESCRIPTION
Switches the plotInterp operator to be the 1D interpolation operator in Quads and Hexes. This helps reduce setup time for very high order meshes, and reduces interpolation time when plotting. 

