### PR TITLE
[Mesh] Enable using BOX mesh with any number of MPI ranks

### DIFF
--- a/include/core.hpp
+++ b/include/core.hpp
@@ -41,6 +41,14 @@ void parallelSort(int size, int rank, MPI_Comm comm,
       void (*match)(void *, void *)
       );
 
+// find a factorization n = nx*ny such that
+//  nx>=ny are 'close' to one another
+void factor2(const int n, int &nx, int &ny);
+
+// find a factorization n = nx*ny*nz such that
+//  nx>=ny>=nz are all 'close' to one another
+void factor3(const int n, int &nx, int &ny, int &nz);
+
 void matrixRightSolve(int NrowsA, int NcolsA, double *A, int NrowsB, int NcolsB, double *B, double *C);
 void matrixRightSolve(int NrowsA, int NcolsA, float *A, int NrowsB, int NcolsB, float *B, float *C);
 void matrixUnderdeterminedRightSolveMinNorm(int NrowsA, int NcolsA, dfloat *A, dfloat *b, dfloat *x);

--- a/libs/core/factor.cpp
+++ b/libs/core/factor.cpp
@@ -1,0 +1,89 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "core.hpp"
+
+// find a factorization n = nx*ny such that
+//  nx>=ny are 'close' to one another
+void factor2(const int n, int &nx, int &ny) {
+  //start with guessing nx ~= n^1/2
+  nx = round(sqrt(n));
+  ny = 1;
+
+  for (;nx<n;nx++) {
+    if (n % nx ==0) { //if nx divides n
+      ny = n / nx; //divide out nx
+
+      //swap if needed
+      if (ny>nx) std::swap(nx,ny);
+
+      return;
+    }
+  }
+
+  //if we made it this far, n is prime
+  nx = n;
+}
+
+// find a factorization n = nx*ny*nz such that
+//  nx>=ny>=nz are all 'close' to one another
+void factor3(const int n, int &nx, int &ny, int &nz) {
+  //start with guessing nx ~= n^1/3
+  nx = round(std::cbrt(n));
+  ny = nz = 1;
+
+  for (;nx<n;nx++) {
+    if (n % nx ==0) { //if nx divides n
+      const int f = n / nx; //divide out nx
+
+      ny = round(sqrt(f)); //guess ny ~= sqrt(f)
+      for (;ny<f;ny++) {
+        if (f % ny == 0) { //if ny divides f
+          nz = f/ny; //divide out ny
+
+          //sort
+          if (ny>nx) std::swap(nx,ny);
+          if (nz>ny) std::swap(ny,nz);
+          if (ny>nx) std::swap(nx,ny);
+
+          return;
+        }
+      }
+
+      //if we're here, f is prime
+      ny = f;
+      nz = 1;
+
+      //swap if needed
+      if (ny>nx) std::swap(nx,ny);
+
+      return;
+    }
+  }
+
+  //if we made it this far, n is prime
+  nx = n;
+}

--- a/libs/mesh/meshSettings.cpp
+++ b/libs/mesh/meshSettings.cpp
@@ -65,6 +65,16 @@ meshSettings_t::meshSettings_t(MPI_Comm& _comm):
              "10",
              "Number of elements in Z-dimension per rank");
 
+  newSetting("BOX GLOBAL NX",
+             "0",
+             "Global number of elements in X-dimension per rank");
+  newSetting("BOX GLOBAL NY",
+             "0",
+             "Global number of elements in Y-dimension per rank");
+  newSetting("BOX GLOBAL NZ",
+             "0",
+             "Global number of elements in Z-dimension per rank");
+
   newSetting("BOX BOUNDARY FLAG",
              "1",
              "Type of boundary conditions for BOX domain (-1 for periodic)");
@@ -97,9 +107,22 @@ void meshSettings_t::report() {
       reportSetting("BOX DIMX");
       reportSetting("BOX DIMY");
       reportSetting("BOX DIMZ");
-      reportSetting("BOX NX");
-      reportSetting("BOX NY");
-      reportSetting("BOX NZ");
+
+      dlong NX, NY, NZ;
+      getSetting("BOX GLOBAL NX", NX);
+      getSetting("BOX GLOBAL NY", NY);
+      getSetting("BOX GLOBAL NZ", NZ);
+
+      if (NX*NY*NZ > 0) {
+        reportSetting("BOX GLOBAL NX");
+        reportSetting("BOX GLOBAL NY");
+        reportSetting("BOX GLOBAL NZ");
+      } else {//global sizes not provided, report local size
+        reportSetting("BOX NX");
+        reportSetting("BOX NY");
+        reportSetting("BOX NZ");
+      }
+
       reportSetting("BOX BOUNDARY FLAG");
     }
 

--- a/libs/mesh/meshSetupBoxHex3D.cpp
+++ b/libs/mesh/meshSetupBoxHex3D.cpp
@@ -43,11 +43,22 @@ void meshHex3D::SetupBox(){
 
   memcpy(faceVertices, _faceVertices[0], NfaceVertices*Nfaces*sizeof(int));
 
-  //local grid physical sizes
-  dfloat DIMX, DIMY, DIMZ;
-  settings.getSetting("BOX DIMX", DIMX);
-  settings.getSetting("BOX DIMY", DIMY);
-  settings.getSetting("BOX DIMZ", DIMZ);
+  // find a factorization size = size_x*size_y*size_z such that
+  //  size_x>=size_y>=size_z are all 'close' to one another
+  int size_x, size_y, size_z;
+  factor3(size, size_x, size_y, size_z);
+
+  //find our coordinates in the MPI grid such that
+  // rank = rank_x + rank_y*size_x + rank_z*size_x*size_y
+  int rank_z = rank/(size_x*size_y);
+  int rank_y = (rank-rank_z*size_x*size_y)/size_x;
+  int rank_x = rank % size_x;
+
+  //get global size from settings
+  dlong NX, NY, NZ;
+  settings.getSetting("BOX GLOBAL NX", NX);
+  settings.getSetting("BOX GLOBAL NY", NY);
+  settings.getSetting("BOX GLOBAL NZ", NZ);
 
   //number of local elements in each dimension
   dlong nx, ny, nz;
@@ -55,34 +66,45 @@ void meshHex3D::SetupBox(){
   settings.getSetting("BOX NY", ny);
   settings.getSetting("BOX NZ", nz);
 
-  int size_x = std::cbrt(size); //number of ranks in each dimension
-  if (size_x*size_x*size_x != size)
-    LIBP_ABORT(string("3D BOX mesh requires a cubic number of ranks for now."))
+  if (NX*NY*NZ <= 0) { //if the user hasn't given global sizes
+    //set global size by multiplying local size by grid dims
+    NX = nx * size_x;
+    NY = ny * size_y;
+    NZ = nz * size_z;
+    settings.changeSetting("BOX GLOBAL NX", std::to_string(NX));
+    settings.changeSetting("BOX GLOBAL NY", std::to_string(NY));
+    settings.changeSetting("BOX GLOBAL NZ", std::to_string(NZ));
+  } else {
+    //WARNING setting global sizes on input overrides any local sizes provided
+    nx = NX/size_x + ((rank_x < (NX % size_x)) ? 1 : 0);
+    ny = NY/size_y + ((rank_y < (NY % size_y)) ? 1 : 0);
+    nz = NZ/size_z + ((rank_z < (NZ % size_z)) ? 1 : 0);
+  }
 
   int boundaryFlag;
   settings.getSetting("BOX BOUNDARY FLAG", boundaryFlag);
 
   const int periodicFlag = (boundaryFlag == -1) ? 1 : 0;
 
-  //local grid physical sizes
-  dfloat dimx = DIMX/size_x;
-  dfloat dimy = DIMY/size_x;
-  dfloat dimz = DIMZ/size_x;
+  //grid physical sizes
+  dfloat DIMX, DIMY, DIMZ;
+  settings.getSetting("BOX DIMX", DIMX);
+  settings.getSetting("BOX DIMY", DIMY);
+  settings.getSetting("BOX DIMZ", DIMZ);
 
-  //rank coordinates
-  int rank_z = rank / (size_x*size_x);
-  int rank_y = (rank - rank_z*size_x*size_x) / size_x;
-  int rank_x = rank % size_x;
+  //element sizes
+  dfloat dx = DIMX/NX;
+  dfloat dy = DIMY/NY;
+  dfloat dz = DIMZ/NZ;
+
+  dlong offset_x = rank_x*(NX/size_x) + mymin(rank_x, (NX % size_x));
+  dlong offset_y = rank_y*(NY/size_y) + mymin(rank_y, (NY % size_y));
+  dlong offset_z = rank_z*(NZ/size_z) + mymin(rank_z, (NZ % size_z));
 
   //bottom corner of physical domain
-  dfloat X0 = -DIMX/2.0 + rank_x*dimx;
-  dfloat Y0 = -DIMY/2.0 + rank_y*dimy;
-  dfloat Z0 = -DIMZ/2.0 + rank_z*dimz;
-
-  //global number of elements in each dimension
-  hlong NX = size_x*nx;
-  hlong NY = size_x*ny;
-  hlong NZ = size_x*nz;
+  dfloat X0 = -DIMX/2.0 + offset_x*dx;
+  dfloat Y0 = -DIMY/2.0 + offset_y*dy;
+  dfloat Z0 = -DIMZ/2.0 + offset_z*dz;
 
   //global number of nodes in each dimension
   hlong NnX = periodicFlag ? NX : NX+1; //lose a node when periodic (repeated node)
@@ -101,19 +123,16 @@ void meshHex3D::SetupBox(){
   elementInfo = (hlong*) calloc(Nelements, sizeof(hlong));
 
   dlong e = 0;
-  dfloat dx = dimx/nx;
-  dfloat dy = dimy/ny;
-  dfloat dz = dimz/nz;
   for(int k=0;k<nz;++k){
     for(int j=0;j<ny;++j){
       for(int i=0;i<nx;++i){
 
-        const hlong i0 = i+rank_x*nx;
-        const hlong i1 = (i+1+rank_x*nx)%NnX;
-        const hlong j0 = j+rank_y*ny;
-        const hlong j1 = (j+1+rank_y*ny)%NnY;
-        const hlong k0 = k+rank_z*nz;
-        const hlong k1 = (k+1+rank_z*nz)%NnZ;
+        const hlong i0 = i+offset_x;
+        const hlong i1 = (i+1+offset_x)%NnX;
+        const hlong j0 = j+offset_y;
+        const hlong j1 = (j+1+offset_y)%NnY;
+        const hlong k0 = k+offset_z;
+        const hlong k1 = (k+1+offset_z)%NnZ;
 
         EToV[e*Nverts+0] = i0 + j0*NnX + k0*NnX*NnY;
         EToV[e*Nverts+1] = i1 + j0*NnX + k0*NnX*NnY;

--- a/libs/mesh/meshSetupBoxQuad2D.cpp
+++ b/libs/mesh/meshSetupBoxQuad2D.cpp
@@ -45,40 +45,58 @@ void meshQuad2D::SetupBox(){
   faceVertices = (int*) calloc(NfaceVertices*Nfaces, sizeof(int));
   memcpy(faceVertices, faceVertices_[0], NfaceVertices*Nfaces*sizeof(int));
 
-  //local grid physical sizes
-  dfloat DIMX, DIMY;
-  settings.getSetting("BOX DIMX", DIMX);
-  settings.getSetting("BOX DIMY", DIMY);
+  // find a factorization size = size_x*size_y such that
+  //  size_x>=size_y and are 'close' to one another
+  int size_x, size_y;
+  factor2(size, size_x, size_y);
+
+  //find our coordinates in the MPI grid such that
+  // rank = rank_x + rank_y*size_x
+  int rank_y = rank / size_x;
+  int rank_x = rank % size_x;
+
+  //get global size from settings
+  dlong NX, NY;
+  settings.getSetting("BOX GLOBAL NX", NX);
+  settings.getSetting("BOX GLOBAL NY", NY);
 
   //number of local elements in each dimension
   dlong nx, ny;
   settings.getSetting("BOX NX", nx);
   settings.getSetting("BOX NY", ny);
 
-  int size_x = std::sqrt(size); //number of ranks in each dimension
-  if (size_x*size_x != size)
-    LIBP_ABORT(string("2D BOX mesh requires a square number of ranks for now."))
+  if (NX*NY <= 0) { //if the user hasn't given global sizes
+    //set global size by multiplying local size by grid dims
+    NX = nx * size_x;
+    NY = ny * size_y;
+    settings.changeSetting("BOX GLOBAL NX", std::to_string(NX));
+    settings.changeSetting("BOX GLOBAL NY", std::to_string(NY));
+  } else {
+    //WARNING setting global sizes on input overrides any local sizes provided
+    nx = NX/size_x + ((rank_x < (NX % size_x)) ? 1 : 0);
+    ny = NY/size_y + ((rank_y < (NY % size_y)) ? 1 : 0);
+  }
 
   int boundaryFlag;
   settings.getSetting("BOX BOUNDARY FLAG", boundaryFlag);
 
   const int periodicFlag = (boundaryFlag == -1) ? 1 : 0;
 
-  //local grid physical sizes
-  dfloat dimx = DIMX/size_x;
-  dfloat dimy = DIMY/size_x;
+  //grid physical sizes
+  dfloat DIMX, DIMY;
+  settings.getSetting("BOX DIMX", DIMX);
+  settings.getSetting("BOX DIMY", DIMY);
 
-  //rank coordinates
-  int rank_y = rank / size_x;
-  int rank_x = rank % size_x;
+  //element sizes
+  dfloat dx = DIMX/NX;
+  dfloat dy = DIMY/NY;
+
+  dlong offset_x = rank_x*(NX/size_x) + mymin(rank_x, (NX % size_x));
+  dlong offset_y = rank_y*(NY/size_y) + mymin(rank_y, (NY % size_y));
 
   //bottom corner of physical domain
-  dfloat X0 = -DIMX/2.0 + rank_x*dimx;
-  dfloat Y0 = -DIMY/2.0 + rank_y*dimy;
-
-  //global number of elements in each dimension
-  hlong NX = size_x*nx;
-  hlong NY = size_x*ny;
+  dfloat X0 = -DIMX/2.0 + offset_x*dx;
+  dfloat Y0 = -DIMY/2.0 + offset_y*dy;
 
   //global number of nodes in each dimension
   hlong NnX = periodicFlag ? NX : NX+1; //lose a node when periodic (repeated node)
@@ -95,15 +113,13 @@ void meshQuad2D::SetupBox(){
   elementInfo = (hlong*) calloc(Nelements, sizeof(hlong));
 
   dlong e = 0;
-  dfloat dx = dimx/nx;
-  dfloat dy = dimy/ny;
   for(int j=0;j<ny;++j){
     for(int i=0;i<nx;++i){
 
-      const hlong i0 = i+rank_x*nx;
-      const hlong i1 = (i+1+rank_x*nx)%NnX;
-      const hlong j0 = j+rank_y*ny;
-      const hlong j1 = (j+1+rank_y*ny)%NnY;
+      const hlong i0 = i+offset_x;
+      const hlong i1 = (i+1+offset_x)%NnX;
+      const hlong j0 = j+offset_y;
+      const hlong j1 = (j+1+offset_y)%NnY;
 
       EToV[e*Nverts+0] = i0 + j0*NnX;
       EToV[e*Nverts+1] = i1 + j0*NnX;

--- a/libs/mesh/meshSetupPmlBoxTet3D.cpp
+++ b/libs/mesh/meshSetupPmlBoxTet3D.cpp
@@ -45,14 +45,22 @@ void meshTet3D::SetupPmlBox(){
   faceVertices = (int*) calloc(NfaceVertices*Nfaces, sizeof(int));
   memcpy(faceVertices, faceVertices_[0], 12*sizeof(int));
 
-  //local grid physical sizes
-  dfloat DIMX, DIMY, DIMZ;
-  settings.getSetting("BOX DIMX", DIMX);
-  settings.getSetting("BOX DIMY", DIMY);
-  settings.getSetting("BOX DIMZ", DIMZ);
+  // find a factorization size = size_x*size_y*size_z such that
+  //  size_x>=size_y>=size_z are all 'close' to one another
+  int size_x, size_y, size_z;
+  factor3(size, size_x, size_y, size_z);
 
-  //relative PML width
-  const dfloat pmlScale = 0.2;
+  //find our coordinates in the MPI grid such that
+  // rank = rank_x + rank_y*size_x + rank_z*size_x*size_y
+  int rank_z = rank/(size_x*size_y);
+  int rank_y = (rank-rank_z*size_x*size_y)/size_x;
+  int rank_x = rank % size_x;
+
+  //get global size from settings
+  dlong NX, NY, NZ;
+  settings.getSetting("BOX GLOBAL NX", NX);
+  settings.getSetting("BOX GLOBAL NY", NY);
+  settings.getSetting("BOX GLOBAL NZ", NZ);
 
   //number of local elements in each dimension
   dlong nx, ny, nz;
@@ -60,9 +68,20 @@ void meshTet3D::SetupPmlBox(){
   settings.getSetting("BOX NY", ny);
   settings.getSetting("BOX NZ", nz);
 
-  int size_x = std::cbrt(size); //number of ranks in each dimension
-  if (size_x*size_x*size_x != size)
-    LIBP_ABORT(string("3D PMLBOX mesh requires a cubic number of ranks for now."))
+  if (NX*NY*NZ <= 0) { //if the user hasn't given global sizes
+    //set global size by multiplying local size by grid dims
+    NX = nx * size_x;
+    NY = ny * size_y;
+    NZ = nz * size_z;
+    settings.changeSetting("BOX GLOBAL NX", std::to_string(NX));
+    settings.changeSetting("BOX GLOBAL NY", std::to_string(NY));
+    settings.changeSetting("BOX GLOBAL NZ", std::to_string(NZ));
+  } else {
+    //WARNING setting global sizes on input overrides any local sizes provided
+    nx = NX/size_x + ((rank_x < (NX % size_x)) ? 1 : 0);
+    ny = NY/size_y + ((rank_y < (NY % size_y)) ? 1 : 0);
+    nz = NZ/size_z + ((rank_z < (NZ % size_z)) ? 1 : 0);
+  }
 
   int boundaryFlag;
   settings.getSetting("BOX BOUNDARY FLAG", boundaryFlag);
@@ -72,33 +91,37 @@ void meshTet3D::SetupPmlBox(){
     LIBP_ABORT(string("Periodic boundary unsupported for PMLBOX mesh."))
 
   //local grid physical sizes
-  dfloat dimx = DIMX/size_x;
-  dfloat dimy = DIMY/size_x;
-  dfloat dimz = DIMZ/size_x;
+  dfloat DIMX, DIMY, DIMZ;
+  settings.getSetting("BOX DIMX", DIMX);
+  settings.getSetting("BOX DIMY", DIMY);
+  settings.getSetting("BOX DIMZ", DIMZ);
+
+  //relative PML width
+  const dfloat pmlScale = 0.2;
+
+  //element sizes
+  dfloat dx = DIMX/NX;
+  dfloat dy = DIMY/NY;
+  dfloat dz = DIMZ/NZ;
+
+  dlong offset_x = rank_x*(NX/size_x) + mymin(rank_x, (NX % size_x));
+  dlong offset_y = rank_y*(NY/size_y) + mymin(rank_y, (NY % size_y));
+  dlong offset_z = rank_z*(NZ/size_z) + mymin(rank_z, (NZ % size_z));
+
+  //local grid physical sizes
+  dfloat dimx = nx*dx;
+  dfloat dimy = ny*dy;
+  dfloat dimz = nz*dz;
 
   //pml width
   dfloat pmlWidthx = pmlScale*DIMX;
   dfloat pmlWidthy = pmlScale*DIMY;
   dfloat pmlWidthz = pmlScale*DIMZ;
 
-  //rank coordinates
-  int rank_z = rank / (size_x*size_x);
-  int rank_y = (rank - rank_z*size_x*size_x) / size_x;
-  int rank_x = rank % size_x;
-
   //bottom corner of physical domain
-  dfloat X0 = -DIMX/2.0 + rank_x*dimx;
-  dfloat Y0 = -DIMY/2.0 + rank_y*dimy;
-  dfloat Z0 = -DIMZ/2.0 + rank_z*dimz;
-
-  //global number of elements in each dimension
-  hlong NX = size_x*nx;
-  hlong NY = size_x*ny;
-  hlong NZ = size_x*nz;
-
-  dfloat dx = dimx/nx;
-  dfloat dy = dimy/ny;
-  dfloat dz = dimz/nz;
+  dfloat X0 = -DIMX/2.0 + offset_x*dx;
+  dfloat Y0 = -DIMY/2.0 + offset_y*dy;
+  dfloat Z0 = -DIMZ/2.0 + offset_z*dz;
 
   //try and have roughly the same resolution in the pml region
   dlong pmlNx, pmlNy, pmlNz;
@@ -129,33 +152,33 @@ void meshTet3D::SetupPmlBox(){
   if (rank_x==0)        Nelements+=6*ny*nz*pmlNx;
   if (rank_x==size_x-1) Nelements+=6*ny*nz*pmlNx;
   if (rank_y==0)        Nelements+=6*nx*nz*pmlNy;
-  if (rank_y==size_x-1) Nelements+=6*nx*nz*pmlNy;
+  if (rank_y==size_y-1) Nelements+=6*nx*nz*pmlNy;
   if (rank_z==0)        Nelements+=6*nx*ny*pmlNz;
-  if (rank_z==size_x-1) Nelements+=6*nx*ny*pmlNz;
+  if (rank_z==size_z-1) Nelements+=6*nx*ny*pmlNz;
 
   // //pml edges
   if (rank_x==0        && rank_y==0       ) Nelements+=6*pmlNx*pmlNy*nz;
   if (rank_x==size_x-1 && rank_y==0       ) Nelements+=6*pmlNx*pmlNy*nz;
-  if (rank_x==0        && rank_y==size_x-1) Nelements+=6*pmlNx*pmlNy*nz;
-  if (rank_x==size_x-1 && rank_y==size_x-1) Nelements+=6*pmlNx*pmlNy*nz;
+  if (rank_x==0        && rank_y==size_y-1) Nelements+=6*pmlNx*pmlNy*nz;
+  if (rank_x==size_x-1 && rank_y==size_y-1) Nelements+=6*pmlNx*pmlNy*nz;
   if (rank_x==0        && rank_z==0       ) Nelements+=6*pmlNx*pmlNz*ny;
   if (rank_x==size_x-1 && rank_z==0       ) Nelements+=6*pmlNx*pmlNz*ny;
-  if (rank_x==0        && rank_z==size_x-1) Nelements+=6*pmlNx*pmlNz*ny;
-  if (rank_x==size_x-1 && rank_z==size_x-1) Nelements+=6*pmlNx*pmlNz*ny;
+  if (rank_x==0        && rank_z==size_z-1) Nelements+=6*pmlNx*pmlNz*ny;
+  if (rank_x==size_x-1 && rank_z==size_z-1) Nelements+=6*pmlNx*pmlNz*ny;
   if (rank_y==0        && rank_z==0       ) Nelements+=6*pmlNy*pmlNz*nx;
-  if (rank_y==size_x-1 && rank_z==0       ) Nelements+=6*pmlNy*pmlNz*nx;
-  if (rank_y==0        && rank_z==size_x-1) Nelements+=6*pmlNy*pmlNz*nx;
-  if (rank_y==size_x-1 && rank_z==size_x-1) Nelements+=6*pmlNy*pmlNz*nx;
+  if (rank_y==size_y-1 && rank_z==0       ) Nelements+=6*pmlNy*pmlNz*nx;
+  if (rank_y==0        && rank_z==size_z-1) Nelements+=6*pmlNy*pmlNz*nx;
+  if (rank_y==size_y-1 && rank_z==size_z-1) Nelements+=6*pmlNy*pmlNz*nx;
 
   //pml corners
   if (rank_x==0        && rank_y==0        && rank_z==0       ) Nelements+=6*pmlNx*pmlNy*pmlNz;
   if (rank_x==size_x-1 && rank_y==0        && rank_z==0       ) Nelements+=6*pmlNx*pmlNy*pmlNz;
-  if (rank_x==0        && rank_y==size_x-1 && rank_z==0       ) Nelements+=6*pmlNx*pmlNy*pmlNz;
-  if (rank_x==size_x-1 && rank_y==size_x-1 && rank_z==0       ) Nelements+=6*pmlNx*pmlNy*pmlNz;
-  if (rank_x==0        && rank_y==0        && rank_z==size_x-1) Nelements+=6*pmlNx*pmlNy*pmlNz;
-  if (rank_x==size_x-1 && rank_y==0        && rank_z==size_x-1) Nelements+=6*pmlNx*pmlNy*pmlNz;
-  if (rank_x==0        && rank_y==size_x-1 && rank_z==size_x-1) Nelements+=6*pmlNx*pmlNy*pmlNz;
-  if (rank_x==size_x-1 && rank_y==size_x-1 && rank_z==size_x-1) Nelements+=6*pmlNx*pmlNy*pmlNz;
+  if (rank_x==0        && rank_y==size_y-1 && rank_z==0       ) Nelements+=6*pmlNx*pmlNy*pmlNz;
+  if (rank_x==size_x-1 && rank_y==size_y-1 && rank_z==0       ) Nelements+=6*pmlNx*pmlNy*pmlNz;
+  if (rank_x==0        && rank_y==0        && rank_z==size_z-1) Nelements+=6*pmlNx*pmlNy*pmlNz;
+  if (rank_x==size_x-1 && rank_y==0        && rank_z==size_z-1) Nelements+=6*pmlNx*pmlNy*pmlNz;
+  if (rank_x==0        && rank_y==size_y-1 && rank_z==size_z-1) Nelements+=6*pmlNx*pmlNy*pmlNz;
+  if (rank_x==size_x-1 && rank_y==size_y-1 && rank_z==size_z-1) Nelements+=6*pmlNx*pmlNy*pmlNz;
 
   EToV = (hlong*) calloc(Nelements*Nverts, sizeof(hlong));
   EX = (dfloat*) calloc(Nelements*Nverts, sizeof(dfloat));
@@ -169,9 +192,9 @@ void meshTet3D::SetupPmlBox(){
     for(int j=0;j<ny;++j){
       for(int i=0;i<nx;++i){
 
-        const hlong i0 = i+rank_x*nx + pmlNx;
-        const hlong j0 = j+rank_y*ny + pmlNy;
-        const hlong k0 = k+rank_z*nz + pmlNz;
+        const hlong i0 = i+offset_x + pmlNx;
+        const hlong j0 = j+offset_y + pmlNy;
+        const hlong k0 = k+offset_z + pmlNz;
 
         dfloat x0 = X0 + dx*i;
         dfloat y0 = Y0 + dy*j;
@@ -193,9 +216,9 @@ void meshTet3D::SetupPmlBox(){
       for(int j=0;j<ny;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx;
-          const hlong j0 = j+rank_y*ny + pmlNy;
-          const hlong k0 = k+rank_z*nz + pmlNz;
+          const hlong i0 = i+offset_x;
+          const hlong j0 = j+offset_y + pmlNy;
+          const hlong k0 = k+offset_z + pmlNz;
 
           dfloat x0 = X0-pmlWidthx + pmldx*i;
           dfloat y0 = Y0 + dy*j;
@@ -218,9 +241,9 @@ void meshTet3D::SetupPmlBox(){
       for(int j=0;j<ny;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx + pmlNx + nx;
-          const hlong j0 = j+rank_y*ny + pmlNy;
-          const hlong k0 = k+rank_z*nz + pmlNz;
+          const hlong i0 = i+offset_x + pmlNx + nx;
+          const hlong j0 = j+offset_y + pmlNy;
+          const hlong k0 = k+offset_z + pmlNz;
 
           dfloat x0 = X0 + dimx + pmldx*i;
           dfloat y0 = Y0 + dy*j;
@@ -243,9 +266,9 @@ void meshTet3D::SetupPmlBox(){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<nx;++i){
 
-          const hlong i0 = i+rank_x*nx + pmlNx;
-          const hlong j0 = j+rank_y*ny;
-          const hlong k0 = k+rank_z*nz + pmlNz;
+          const hlong i0 = i+offset_x + pmlNx;
+          const hlong j0 = j+offset_y;
+          const hlong k0 = k+offset_z + pmlNz;
 
           dfloat x0 = X0 + dx*i;
           dfloat y0 = Y0-pmlWidthy + pmldy*j;
@@ -263,14 +286,14 @@ void meshTet3D::SetupPmlBox(){
   }
 
   //Y+ pml
-  if (rank_y==size_x-1) {
+  if (rank_y==size_y-1) {
     for(int k=0;k<nz;++k){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<nx;++i){
 
-          const hlong i0 = i+rank_x*nx + pmlNx;
-          const hlong j0 = j+rank_y*ny + pmlNy + ny;
-          const hlong k0 = k+rank_z*nz + pmlNz;
+          const hlong i0 = i+offset_x + pmlNx;
+          const hlong j0 = j+offset_y + pmlNy + ny;
+          const hlong k0 = k+offset_z + pmlNz;
 
           dfloat x0 = X0 + dx*i;
           dfloat y0 = Y0 + dimy + pmldy*j;
@@ -293,9 +316,9 @@ void meshTet3D::SetupPmlBox(){
       for(int j=0;j<ny;++j){
         for(int i=0;i<nx;++i){
 
-          const hlong i0 = i+rank_x*nx + pmlNx;
-          const hlong j0 = j+rank_y*ny + pmlNy;
-          const hlong k0 = k+rank_z*nz;
+          const hlong i0 = i+offset_x + pmlNx;
+          const hlong j0 = j+offset_y + pmlNy;
+          const hlong k0 = k+offset_z;
 
           dfloat x0 = X0 + dx*i;
           dfloat y0 = Y0 + dy*j;
@@ -313,14 +336,14 @@ void meshTet3D::SetupPmlBox(){
   }
 
   //Z+ pml
-  if (rank_z==size_x-1) {
+  if (rank_z==size_z-1) {
     for(int k=0;k<pmlNz;++k){
       for(int j=0;j<ny;++j){
         for(int i=0;i<nx;++i){
 
-          const hlong i0 = i+rank_x*nx + pmlNx;
-          const hlong j0 = j+rank_y*ny + pmlNy;
-          const hlong k0 = k+rank_z*nz + pmlNz + nz;
+          const hlong i0 = i+offset_x + pmlNx;
+          const hlong j0 = j+offset_y + pmlNy;
+          const hlong k0 = k+offset_z + pmlNz + nz;
 
           dfloat x0 = X0 + dx*i;
           dfloat y0 = Y0 + dy*j;
@@ -343,9 +366,9 @@ void meshTet3D::SetupPmlBox(){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx;
-          const hlong j0 = j+rank_y*ny;
-          const hlong k0 = k+rank_z*nz + pmlNz;
+          const hlong i0 = i+offset_x;
+          const hlong j0 = j+offset_y;
+          const hlong k0 = k+offset_z + pmlNz;
 
           dfloat x0 = X0-pmlWidthx + pmldx*i;
           dfloat y0 = Y0-pmlWidthy + pmldy*j;
@@ -367,9 +390,9 @@ void meshTet3D::SetupPmlBox(){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx + pmlNx + nx;
-          const hlong j0 = j+rank_y*ny;
-          const hlong k0 = k+rank_z*nz + pmlNz;
+          const hlong i0 = i+offset_x + pmlNx + nx;
+          const hlong j0 = j+offset_y;
+          const hlong k0 = k+offset_z + pmlNz;
 
           dfloat x0 = X0+dimx + pmldx*i;
           dfloat y0 = Y0-pmlWidthy + pmldy*j;
@@ -386,14 +409,14 @@ void meshTet3D::SetupPmlBox(){
     }
   }
   //X-Y+ pml
-  if (rank_x==0 && rank_y==size_x-1) {
+  if (rank_x==0 && rank_y==size_y-1) {
     for(int k=0;k<nz;++k){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx;
-          const hlong j0 = j+rank_y*ny + pmlNy + ny;
-          const hlong k0 = k+rank_z*nz + pmlNz;
+          const hlong i0 = i+offset_x;
+          const hlong j0 = j+offset_y + pmlNy + ny;
+          const hlong k0 = k+offset_z + pmlNz;
 
           dfloat x0 = X0-pmlWidthx + pmldx*i;
           dfloat y0 = Y0+dimy + pmldy*j;
@@ -410,14 +433,14 @@ void meshTet3D::SetupPmlBox(){
     }
   }
   //X+Y+ pml
-  if (rank_x==size_x-1 && rank_y==size_x-1) {
+  if (rank_x==size_x-1 && rank_y==size_y-1) {
     for(int k=0;k<nz;++k){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx + pmlNx + nx;
-          const hlong j0 = j+rank_y*ny + pmlNy + ny;
-          const hlong k0 = k+rank_z*nz + pmlNz;
+          const hlong i0 = i+offset_x + pmlNx + nx;
+          const hlong j0 = j+offset_y + pmlNy + ny;
+          const hlong k0 = k+offset_z + pmlNz;
 
           dfloat x0 = X0+dimx + pmldx*i;
           dfloat y0 = Y0+dimy + pmldy*j;
@@ -440,9 +463,9 @@ void meshTet3D::SetupPmlBox(){
       for(int j=0;j<ny;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx;
-          const hlong j0 = j+rank_y*ny + pmlNy;
-          const hlong k0 = k+rank_z*nz;
+          const hlong i0 = i+offset_x;
+          const hlong j0 = j+offset_y + pmlNy;
+          const hlong k0 = k+offset_z;
 
           dfloat x0 = X0-pmlWidthx + pmldx*i;
           dfloat y0 = Y0 + dy*j;
@@ -464,9 +487,9 @@ void meshTet3D::SetupPmlBox(){
       for(int j=0;j<ny;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx + pmlNx + nx;
-          const hlong j0 = j+rank_y*ny + pmlNy;
-          const hlong k0 = k+rank_z*nz;
+          const hlong i0 = i+offset_x + pmlNx + nx;
+          const hlong j0 = j+offset_y + pmlNy;
+          const hlong k0 = k+offset_z;
 
           dfloat x0 = X0+dimx + pmldx*i;
           dfloat y0 = Y0 + dy*j;
@@ -483,14 +506,14 @@ void meshTet3D::SetupPmlBox(){
     }
   }
   //X-Z+ pml
-  if (rank_x==0 && rank_z==size_x-1) {
+  if (rank_x==0 && rank_z==size_z-1) {
     for(int k=0;k<pmlNz;++k){
       for(int j=0;j<ny;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx;
-          const hlong j0 = j+rank_y*ny + pmlNy;
-          const hlong k0 = k+rank_z*nz + pmlNz + nz;
+          const hlong i0 = i+offset_x;
+          const hlong j0 = j+offset_y + pmlNy;
+          const hlong k0 = k+offset_z + pmlNz + nz;
 
           dfloat x0 = X0-pmlWidthx + pmldx*i;
           dfloat y0 = Y0 + dy*j;
@@ -507,14 +530,14 @@ void meshTet3D::SetupPmlBox(){
     }
   }
   //X+Z+ pml
-  if (rank_x==size_x-1 && rank_z==size_x-1) {
+  if (rank_x==size_x-1 && rank_z==size_z-1) {
     for(int k=0;k<pmlNz;++k){
       for(int j=0;j<ny;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx + pmlNx + nx;
-          const hlong j0 = j+rank_y*ny + pmlNy;
-          const hlong k0 = k+rank_z*nz + pmlNz + nz;
+          const hlong i0 = i+offset_x + pmlNx + nx;
+          const hlong j0 = j+offset_y + pmlNy;
+          const hlong k0 = k+offset_z + pmlNz + nz;
 
           dfloat x0 = X0+dimx + pmldx*i;
           dfloat y0 = Y0 + dy*j;
@@ -532,14 +555,14 @@ void meshTet3D::SetupPmlBox(){
   }
 
   //Y-Z- pml
-  if (rank_x==0 && rank_z==0) {
+  if (rank_y==0 && rank_z==0) {
     for(int k=0;k<pmlNz;++k){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<nx;++i){
 
-          const hlong i0 = i+rank_x*nx + pmlNx;
-          const hlong j0 = j+rank_y*ny;
-          const hlong k0 = k+rank_z*nz;
+          const hlong i0 = i+offset_x + pmlNx;
+          const hlong j0 = j+offset_y;
+          const hlong k0 = k+offset_z;
 
           dfloat x0 = X0 + dx*i;
           dfloat y0 = Y0-pmlWidthy + pmldy*j;
@@ -556,14 +579,14 @@ void meshTet3D::SetupPmlBox(){
     }
   }
   //Y+Z- pml
-  if (rank_y==size_x-1 && rank_z==0) {
+  if (rank_y==size_y-1 && rank_z==0) {
     for(int k=0;k<pmlNz;++k){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<nx;++i){
 
-          const hlong i0 = i+rank_x*nx + pmlNx;
-          const hlong j0 = j+rank_y*ny + pmlNy + ny;
-          const hlong k0 = k+rank_z*nz;
+          const hlong i0 = i+offset_x + pmlNx;
+          const hlong j0 = j+offset_y + pmlNy + ny;
+          const hlong k0 = k+offset_z;
 
           dfloat x0 = X0 + dx*i;
           dfloat y0 = Y0+dimy + pmldy*j;
@@ -580,14 +603,14 @@ void meshTet3D::SetupPmlBox(){
     }
   }
   //Y-Z+ pml
-  if (rank_y==0 && rank_z==size_x-1) {
+  if (rank_y==0 && rank_z==size_z-1) {
     for(int k=0;k<pmlNz;++k){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<nx;++i){
 
-          const hlong i0 = i+rank_x*nx + pmlNx;
-          const hlong j0 = j+rank_y*ny;
-          const hlong k0 = k+rank_z*nz + pmlNz + nz;
+          const hlong i0 = i+offset_x + pmlNx;
+          const hlong j0 = j+offset_y;
+          const hlong k0 = k+offset_z + pmlNz + nz;
 
           dfloat x0 = X0 + dx*i;
           dfloat y0 = Y0-pmlWidthy + pmldy*j;
@@ -604,14 +627,14 @@ void meshTet3D::SetupPmlBox(){
     }
   }
   //Y+Z+ pml
-  if (rank_y==size_x-1 && rank_z==size_x-1) {
+  if (rank_y==size_y-1 && rank_z==size_z-1) {
     for(int k=0;k<pmlNz;++k){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<nx;++i){
 
-          const hlong i0 = i+rank_x*nx + pmlNx;
-          const hlong j0 = j+rank_y*ny + pmlNy + ny;
-          const hlong k0 = k+rank_z*nz + pmlNz + nz;
+          const hlong i0 = i+offset_x + pmlNx;
+          const hlong j0 = j+offset_y + pmlNy + ny;
+          const hlong k0 = k+offset_z + pmlNz + nz;
 
           dfloat x0 = X0 + dx*i;
           dfloat y0 = Y0+dimy + pmldy*j;
@@ -634,9 +657,9 @@ void meshTet3D::SetupPmlBox(){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx;
-          const hlong j0 = j+rank_y*ny;
-          const hlong k0 = k+rank_z*nz;
+          const hlong i0 = i+offset_x;
+          const hlong j0 = j+offset_y;
+          const hlong k0 = k+offset_z;
 
           dfloat x0 = X0-pmlWidthx + pmldx*i;
           dfloat y0 = Y0-pmlWidthy + pmldy*j;
@@ -658,9 +681,9 @@ void meshTet3D::SetupPmlBox(){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx + pmlNx + nx;
-          const hlong j0 = j+rank_y*ny;
-          const hlong k0 = k+rank_z*nz;
+          const hlong i0 = i+offset_x + pmlNx + nx;
+          const hlong j0 = j+offset_y;
+          const hlong k0 = k+offset_z;
 
           dfloat x0 = X0+dimx + pmldx*i;
           dfloat y0 = Y0-pmlWidthy + pmldy*j;
@@ -677,14 +700,14 @@ void meshTet3D::SetupPmlBox(){
     }
   }
   //X-Y+Z- pml
-  if (rank_x==0 && rank_y==size_x-1 && rank_z==0) {
+  if (rank_x==0 && rank_y==size_y-1 && rank_z==0) {
     for(int k=0;k<pmlNz;++k){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx;
-          const hlong j0 = j+rank_y*ny + pmlNy + ny;
-          const hlong k0 = k+rank_z*nz;
+          const hlong i0 = i+offset_x;
+          const hlong j0 = j+offset_y + pmlNy + ny;
+          const hlong k0 = k+offset_z;
 
           dfloat x0 = X0-pmlWidthx + pmldx*i;
           dfloat y0 = Y0+dimy + pmldy*j;
@@ -701,14 +724,14 @@ void meshTet3D::SetupPmlBox(){
     }
   }
   //X+Y+Z- pml
-  if (rank_x==size_x-1 && rank_y==size_x-1 && rank_z==0) {
+  if (rank_x==size_x-1 && rank_y==size_y-1 && rank_z==0) {
     for(int k=0;k<pmlNz;++k){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx + pmlNx + nx;
-          const hlong j0 = j+rank_y*ny + pmlNy + ny;
-          const hlong k0 = k+rank_z*nz;
+          const hlong i0 = i+offset_x + pmlNx + nx;
+          const hlong j0 = j+offset_y + pmlNy + ny;
+          const hlong k0 = k+offset_z;
 
           dfloat x0 = X0+dimx + pmldx*i;
           dfloat y0 = Y0+dimy + pmldy*j;
@@ -725,14 +748,14 @@ void meshTet3D::SetupPmlBox(){
     }
   }
   //X-Y-Z+ pml
-  if (rank_x==0 && rank_y==0 && rank_z==size_x-1) {
+  if (rank_x==0 && rank_y==0 && rank_z==size_z-1) {
     for(int k=0;k<pmlNz;++k){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx;
-          const hlong j0 = j+rank_y*ny;
-          const hlong k0 = k+rank_z*nz + pmlNz + nz;
+          const hlong i0 = i+offset_x;
+          const hlong j0 = j+offset_y;
+          const hlong k0 = k+offset_z + pmlNz + nz;
 
           dfloat x0 = X0-pmlWidthx + pmldx*i;
           dfloat y0 = Y0-pmlWidthy + pmldy*j;
@@ -749,14 +772,14 @@ void meshTet3D::SetupPmlBox(){
     }
   }
   //X+Y-Z+ pml
-  if (rank_x==size_x-1 && rank_y==0 && rank_z==size_x-1) {
+  if (rank_x==size_x-1 && rank_y==0 && rank_z==size_z-1) {
     for(int k=0;k<pmlNz;++k){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx + pmlNx + nx;
-          const hlong j0 = j+rank_y*ny;
-          const hlong k0 = k+rank_z*nz + pmlNz + nz;
+          const hlong i0 = i+offset_x + pmlNx + nx;
+          const hlong j0 = j+offset_y;
+          const hlong k0 = k+offset_z + pmlNz + nz;
 
           dfloat x0 = X0+dimx + pmldx*i;
           dfloat y0 = Y0-pmlWidthy + pmldy*j;
@@ -773,14 +796,14 @@ void meshTet3D::SetupPmlBox(){
     }
   }
   //X-Y+Z+ pml
-  if (rank_x==0 && rank_y==size_x-1 && rank_z==size_x-1) {
+  if (rank_x==0 && rank_y==size_y-1 && rank_z==size_z-1) {
     for(int k=0;k<pmlNz;++k){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx;
-          const hlong j0 = j+rank_y*ny + pmlNy + ny;
-          const hlong k0 = k+rank_z*nz + pmlNz + nz;
+          const hlong i0 = i+offset_x;
+          const hlong j0 = j+offset_y + pmlNy + ny;
+          const hlong k0 = k+offset_z + pmlNz + nz;
 
           dfloat x0 = X0-pmlWidthx + pmldx*i;
           dfloat y0 = Y0+dimy + pmldy*j;
@@ -797,14 +820,14 @@ void meshTet3D::SetupPmlBox(){
     }
   }
   //X+Y+Z+ pml
-  if (rank_x==size_x-1 && rank_y==size_x-1 && rank_z==size_x-1) {
+  if (rank_x==size_x-1 && rank_y==size_y-1 && rank_z==size_z-1) {
     for(int k=0;k<pmlNz;++k){
       for(int j=0;j<pmlNy;++j){
         for(int i=0;i<pmlNx;++i){
 
-          const hlong i0 = i+rank_x*nx + pmlNx + nx;
-          const hlong j0 = j+rank_y*ny + pmlNy + ny;
-          const hlong k0 = k+rank_z*nz + pmlNz + nz;
+          const hlong i0 = i+offset_x + pmlNx + nx;
+          const hlong j0 = j+offset_y + pmlNy + ny;
+          const hlong k0 = k+offset_z + pmlNz + nz;
 
           dfloat x0 = X0+dimx + pmldx*i;
           dfloat y0 = Y0+dimy + pmldy*j;

--- a/libs/mesh/meshSetupPmlBoxTri2D.cpp
+++ b/libs/mesh/meshSetupPmlBoxTri2D.cpp
@@ -45,22 +45,37 @@ void meshTri2D::SetupPmlBox(){
   faceVertices = (int*) calloc(NfaceVertices*Nfaces, sizeof(int));
   memcpy(faceVertices, faceVertices_[0], NfaceVertices*Nfaces*sizeof(int));
 
-  //local grid physical sizes
-  dfloat DIMX, DIMY;
-  settings.getSetting("BOX DIMX", DIMX);
-  settings.getSetting("BOX DIMY", DIMY);
+  // find a factorization size = size_x*size_y such that
+  //  size_x>=size_y and are all 'close' to one another
+  int size_x, size_y;
+  factor2(size, size_x, size_y);
 
-  //relative PML width
-  const dfloat pmlScale = 0.2;
+  //find our coordinates in the MPI grid such that
+  // rank = rank_x + rank_y*size_x
+  int rank_y = rank / size_x;
+  int rank_x = rank % size_x;
+
+  //get global size from settings
+  dlong NX, NY;
+  settings.getSetting("BOX GLOBAL NX", NX);
+  settings.getSetting("BOX GLOBAL NY", NY);
 
   //number of local elements in each dimension
   dlong nx, ny;
   settings.getSetting("BOX NX", nx);
   settings.getSetting("BOX NY", ny);
 
-  int size_x = std::sqrt(size); //number of ranks in each dimension
-  if (size_x*size_x != size)
-    LIBP_ABORT(string("2D PMLBOX mesh requires a square number of ranks for now."))
+  if (NX*NY <= 0) { //if the user hasn't given global sizes
+    //set global size by multiplying local size by grid dims
+    NX = nx * size_x;
+    NY = ny * size_y;
+    settings.changeSetting("BOX GLOBAL NX", std::to_string(NX));
+    settings.changeSetting("BOX GLOBAL NY", std::to_string(NY));
+  } else {
+    //WARNING setting global sizes on input overrides any local sizes provided
+    nx = NX/size_x + ((rank_x < (NX % size_x)) ? 1 : 0);
+    ny = NY/size_y + ((rank_y < (NY % size_y)) ? 1 : 0);
+  }
 
   int boundaryFlag;
   settings.getSetting("BOX BOUNDARY FLAG", boundaryFlag);
@@ -70,27 +85,31 @@ void meshTri2D::SetupPmlBox(){
     LIBP_ABORT(string("Periodic boundary unsupported for PMLBOX mesh."))
 
   //local grid physical sizes
-  dfloat dimx = DIMX/size_x;
-  dfloat dimy = DIMY/size_x;
+  dfloat DIMX, DIMY;
+  settings.getSetting("BOX DIMX", DIMX);
+  settings.getSetting("BOX DIMY", DIMY);
+
+  //relative PML width
+  const dfloat pmlScale = 0.2;
+
+  //element sizes
+  dfloat dx = DIMX/NX;
+  dfloat dy = DIMY/NY;
+
+  dlong offset_x = rank_x*(NX/size_x) + mymin(rank_x, (NX % size_x));
+  dlong offset_y = rank_y*(NY/size_y) + mymin(rank_y, (NY % size_y));
+
+  //local grid physical sizes
+  dfloat dimx = nx*dx;
+  dfloat dimy = ny*dy;
 
   //pml width
   dfloat pmlWidthx = pmlScale*DIMX;
   dfloat pmlWidthy = pmlScale*DIMY;
 
-  //rank coordinates
-  int rank_y = rank / size_x;
-  int rank_x = rank % size_x;
-
   //bottom corner of physical domain
-  dfloat X0 = -DIMX/2.0 + rank_x*dimx;
-  dfloat Y0 = -DIMY/2.0 + rank_y*dimy;
-
-  //global number of elements in each dimension
-  hlong NX = size_x*nx;
-  hlong NY = size_x*ny;
-
-  dfloat dx = dimx/nx;
-  dfloat dy = dimy/ny;
+  dfloat X0 = -DIMX/2.0 + offset_x*dx;
+  dfloat Y0 = -DIMY/2.0 + offset_y*dy;
 
   //try and have roughly the same resolution in the pml region
   dlong pmlNx, pmlNy;
@@ -117,13 +136,13 @@ void meshTri2D::SetupPmlBox(){
   if (rank_x==0)        Nelements+=2*ny*pmlNx;
   if (rank_x==size_x-1) Nelements+=2*ny*pmlNx;
   if (rank_y==0)        Nelements+=2*nx*pmlNy;
-  if (rank_y==size_x-1) Nelements+=2*nx*pmlNy;
+  if (rank_y==size_y-1) Nelements+=2*nx*pmlNy;
 
   //pml corners
   if (rank_x==0        && rank_y==0       ) Nelements+=2*pmlNx*pmlNy;
   if (rank_x==size_x-1 && rank_y==0       ) Nelements+=2*pmlNx*pmlNy;
-  if (rank_x==0        && rank_y==size_x-1) Nelements+=2*pmlNx*pmlNy;
-  if (rank_x==size_x-1 && rank_y==size_x-1) Nelements+=2*pmlNx*pmlNy;
+  if (rank_x==0        && rank_y==size_y-1) Nelements+=2*pmlNx*pmlNy;
+  if (rank_x==size_x-1 && rank_y==size_y-1) Nelements+=2*pmlNx*pmlNy;
 
 
   EToV = (hlong*) calloc(Nelements*Nverts, sizeof(hlong));
@@ -138,10 +157,10 @@ void meshTri2D::SetupPmlBox(){
   for(int j=0;j<ny;++j){
     for(int i=0;i<nx;++i){
 
-      const hlong i0 = i+rank_x*nx + pmlNx;
-      const hlong i1 = (i+1+rank_x*nx + pmlNx)%NnX;
-      const hlong j0 = j+rank_y*ny + pmlNy;
-      const hlong j1 = (j+1+rank_y*ny + pmlNy)%NnY;
+      const hlong i0 = i+offset_x + pmlNx;
+      const hlong i1 = (i+1+offset_x + pmlNx)%NnX;
+      const hlong j0 = j+offset_y + pmlNy;
+      const hlong j1 = (j+1+offset_y + pmlNy)%NnY;
 
       dfloat x0 = X0 + dx*i;
       dfloat y0 = Y0 + dy*j;
@@ -175,10 +194,10 @@ void meshTri2D::SetupPmlBox(){
     for(int j=0;j<ny;++j){
       for(int i=0;i<pmlNx;++i){
 
-        const hlong i0 = i+rank_x*nx;
-        const hlong i1 = (i+1+rank_x*nx)%NnX;
-        const hlong j0 = j+rank_y*ny + pmlNy;
-        const hlong j1 = (j+1+rank_y*ny + pmlNy)%NnY;
+        const hlong i0 = i+offset_x;
+        const hlong i1 = (i+1+offset_x)%NnX;
+        const hlong j0 = j+offset_y + pmlNy;
+        const hlong j1 = (j+1+offset_y + pmlNy)%NnY;
 
         dfloat x0 = X0-pmlWidthx + pmldx*i;
         dfloat y0 = Y0 + dy*j;
@@ -213,10 +232,10 @@ void meshTri2D::SetupPmlBox(){
     for(int j=0;j<ny;++j){
       for(int i=0;i<pmlNx;++i){
 
-        const hlong i0 = i+rank_x*nx + pmlNx + nx;
-        const hlong i1 = (i+1+rank_x*nx + pmlNx + nx)%NnX;
-        const hlong j0 = j+rank_y*ny + pmlNy;
-        const hlong j1 = (j+1+rank_y*ny + pmlNy)%NnY;
+        const hlong i0 = i+offset_x + pmlNx + nx;
+        const hlong i1 = (i+1+offset_x + pmlNx + nx)%NnX;
+        const hlong j0 = j+offset_y + pmlNy;
+        const hlong j1 = (j+1+offset_y + pmlNy)%NnY;
 
         dfloat x0 = X0 + dimx + pmldx*i;
         dfloat y0 = Y0 + dy*j;
@@ -251,10 +270,10 @@ void meshTri2D::SetupPmlBox(){
     for(int j=0;j<pmlNy;++j){
       for(int i=0;i<nx;++i){
 
-        const hlong i0 = i+rank_x*nx + pmlNx;
-        const hlong i1 = (i+1+rank_x*nx + pmlNx)%NnX;
-        const hlong j0 = j+rank_y*ny;
-        const hlong j1 = (j+1+rank_y*ny)%NnY;
+        const hlong i0 = i+offset_x + pmlNx;
+        const hlong i1 = (i+1+offset_x + pmlNx)%NnX;
+        const hlong j0 = j+offset_y;
+        const hlong j1 = (j+1+offset_y)%NnY;
 
         dfloat x0 = X0 + dx*i;
         dfloat y0 = Y0-pmlWidthy + pmldy*j;
@@ -285,14 +304,14 @@ void meshTri2D::SetupPmlBox(){
   }
 
   //Y+ pml
-  if (rank_y==size_x-1) {
+  if (rank_y==size_y-1) {
     for(int j=0;j<pmlNy;++j){
       for(int i=0;i<nx;++i){
 
-        const hlong i0 = i+rank_x*nx + pmlNx;
-        const hlong i1 = (i+1+rank_x*nx + pmlNx)%NnX;
-        const hlong j0 = j+rank_y*ny + pmlNy + ny;
-        const hlong j1 = (j+1+rank_y*ny + pmlNy + ny)%NnY;
+        const hlong i0 = i+offset_x + pmlNx;
+        const hlong i1 = (i+1+offset_x + pmlNx)%NnX;
+        const hlong j0 = j+offset_y + pmlNy + ny;
+        const hlong j1 = (j+1+offset_y + pmlNy + ny)%NnY;
 
         dfloat x0 = X0 + dx*i;
         dfloat y0 = Y0 + dimy + pmldy*j;
@@ -327,10 +346,10 @@ void meshTri2D::SetupPmlBox(){
     for(int j=0;j<pmlNy;++j){
       for(int i=0;i<pmlNx;++i){
 
-        const hlong i0 = i+rank_x*nx;
-        const hlong i1 = (i+1+rank_x*nx)%NnX;
-        const hlong j0 = j+rank_y*ny;
-        const hlong j1 = (j+1+rank_y*ny)%NnY;
+        const hlong i0 = i+offset_x;
+        const hlong i1 = (i+1+offset_x)%NnX;
+        const hlong j0 = j+offset_y;
+        const hlong j1 = (j+1+offset_y)%NnY;
 
         dfloat x0 = X0-pmlWidthx + pmldx*i;
         dfloat y0 = Y0-pmlWidthy + pmldy*j;
@@ -365,10 +384,10 @@ void meshTri2D::SetupPmlBox(){
     for(int j=0;j<pmlNy;++j){
       for(int i=0;i<pmlNx;++i){
 
-        const hlong i0 = i+rank_x*nx + pmlNx + nx;
-        const hlong i1 = (i+1+rank_x*nx + pmlNx + nx)%NnX;
-        const hlong j0 = j+rank_y*ny;
-        const hlong j1 = (j+1+rank_y*ny)%NnY;
+        const hlong i0 = i+offset_x + pmlNx + nx;
+        const hlong i1 = (i+1+offset_x + pmlNx + nx)%NnX;
+        const hlong j0 = j+offset_y;
+        const hlong j1 = (j+1+offset_y)%NnY;
 
         dfloat x0 = X0+dimx      + pmldx*i;
         dfloat y0 = Y0-pmlWidthy + pmldy*j;
@@ -399,14 +418,14 @@ void meshTri2D::SetupPmlBox(){
   }
 
   //X-Y+ pml
-  if (rank_x==0 && rank_y==size_x-1) {
+  if (rank_x==0 && rank_y==size_y-1) {
     for(int j=0;j<pmlNy;++j){
       for(int i=0;i<pmlNx;++i){
 
-        const hlong i0 = i+rank_x*nx;
-        const hlong i1 = (i+1+rank_x*nx)%NnX;
-        const hlong j0 = j+rank_y*ny + pmlNy + ny;
-        const hlong j1 = (j+1+rank_y*ny + pmlNy + ny)%NnY;
+        const hlong i0 = i+offset_x;
+        const hlong i1 = (i+1+offset_x)%NnX;
+        const hlong j0 = j+offset_y + pmlNy + ny;
+        const hlong j1 = (j+1+offset_y + pmlNy + ny)%NnY;
 
         dfloat x0 = X0-pmlWidthx + pmldx*i;
         dfloat y0 = Y0+dimy      + pmldy*j;
@@ -437,14 +456,14 @@ void meshTri2D::SetupPmlBox(){
   }
 
   //X+Y+ pml
-  if (rank_x==size_x-1 && rank_y==size_x-1) {
+  if (rank_x==size_x-1 && rank_y==size_y-1) {
     for(int j=0;j<pmlNy;++j){
       for(int i=0;i<pmlNx;++i){
 
-        const hlong i0 = i+rank_x*nx + pmlNx + nx;
-        const hlong i1 = (i+1+rank_x*nx + pmlNx + nx)%NnX;
-        const hlong j0 = j+rank_y*ny + pmlNy + ny;
-        const hlong j1 = (j+1+rank_y*ny + pmlNy + ny)%NnY;
+        const hlong i0 = i+offset_x + pmlNx + nx;
+        const hlong i1 = (i+1+offset_x + pmlNx + nx)%NnX;
+        const hlong j0 = j+offset_y + pmlNy + ny;
+        const hlong j1 = (j+1+offset_y + pmlNy + ny)%NnY;
 
         dfloat x0 = X0+dimx      + pmldx*i;
         dfloat y0 = Y0+dimy      + pmldy*j;


### PR DESCRIPTION
This PR enables using the BOX and PMLBOX structured meshes with any number of MPI ranks. 

This is done by finding a factorization Nranks = px x py x pz where px>=py>=pz, and px, py, and pz are as close as possible. The global BOX mesh is then subdivided into px slices along the x dimension, and likewise for the y and z dimensions. A similar procedure is done in 2D. 

In addition, if the user wishes to keep the global number of elements in the BOX mesh constant, regardless of the number of MPI ranks, the settings 
- BOX GLOBAL NX
- BOX GLOBAL NY
- BOX GLOBAL NZ

can be specified in place of the usual BOX NX, BOX NY, and BOX NZ. 