### PR TITLE
[Core][Make] Fixing some small changes for building with OCCA's latest main

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ G. Dependencies:
 #### 5-1. Build OCCA
 `cd occa`
 `export OCCA_DIR=${PWD}`
-`export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OCCA_DIR/lib`
 ```make -j `nproc` ```
 `cd ../  `
 

--- a/libs/core/platformDeviceConfig.cpp
+++ b/libs/core/platformDeviceConfig.cpp
@@ -114,9 +114,4 @@ void platform_t::DeviceConfig(){
   std::string occaCacheDir = LIBP_DIR "/.occa";
   settings.getSetting("CACHE DIR", occaCacheDir);
   occa::env::setOccaCacheDir(occaCacheDir);
-
-#ifdef USE_OCCA_MEM_BYTE_ALIGN
-  // change OCCA MEM BYTE ALIGNMENT
-  occa::env::OCCA_MEM_BYTE_ALIGN = USE_OCCA_MEM_BYTE_ALIGN;
-#endif
 }

--- a/make.top
+++ b/make.top
@@ -45,11 +45,6 @@ export LIBP_LAPACK_LIB=-L${LIBP_LAPACK_DIR} -llapack
 ifndef OCCA_DIR
   $(error environment variable [OCCA_DIR] is not set)
 endif
-ifeq (,$(wildcard ${OCCA_DIR}/scripts/Makefile))
-  $(error cannot locate {OCCA_DIR}/scripts/Makefile)
-else
-  include ${OCCA_DIR}/scripts/Makefile
-endif
 
 #compilers to use for C/C++
 export LIBP_MPICC = mpicc
@@ -69,9 +64,9 @@ endif
 
 export LIBP_LIBS=${LIBP_BLAS_LIB} \
                  ${LIBP_LAPACK_LIB} \
-                 -L$(OCCA_DIR)/lib -locca $(links)
+                 -Wl,-rpath=$(OCCA_DIR)/lib -L$(OCCA_DIR)/lib -locca
 
-export LIBP_DEFINES=-DUSE_OCCA_MEM_BYTE_ALIGN=32
+export LIBP_DEFINES=
 
 export LIBP_INCLUDES=-I${LIBP_INCLUDE_DIR} -I${OCCA_DIR}/include
 


### PR DESCRIPTION
Some small tweaks to the build system here. 

- No longer hijacking OCCA's makefile in our build. We don't need anything set in there.
- Linking libocca.so via rpath (which means no more needing `LD_LIBRARY_PATH` !)
- Removing setting `occa::env::OCCA_MEM_BYTE_ALIGN`. This can now be set directly, outside of the build system.  