### PR TITLE
 Changes time-integration scheme parameters from variable to constexpr in timestepper library

### DIFF
--- a/include/timeStepper.hpp
+++ b/include/timeStepper.hpp
@@ -98,7 +98,7 @@ public:
 /* Adams Bashforth, order 3 */
 class ab3: public timeStepperBase_t {
 protected:
-  int Nstages;
+  static constexpr int Nstages{3};
   int shiftIndex;
 
   memory<dfloat> ab_a;
@@ -202,7 +202,7 @@ public:
 /* Semi-Analytic Adams-Bashforth, order 3 */
 class saab3: public timeStepperBase_t {
 protected:
-  int Nstages;
+  static constexpr int Nstages{3};
   int shiftIndex;
 
   int Np, Nfields;
@@ -233,7 +233,7 @@ public:
 /* Semi-Analytic Explict Runge-Kutta, order 4 with embedded order 3 and adaptive time-stepping */
 class sark4: public timeStepperBase_t {
 protected:
-  int Nrk;
+  static constexpr int Nrk{5};
   int order, embeddedOrder;
 
   int Np, Nfields;
@@ -297,7 +297,7 @@ public:
 /* Semi-Analytic Explict Runge-Kutta, order 5 with embedded order 4 and adaptive time-stepping */
 class sark5: public timeStepperBase_t {
 protected:
-  int Nrk;
+  static constexpr int Nrk{7};
   int order, embeddedOrder;
 
   int Np, Nfields;
@@ -362,7 +362,7 @@ public:
 /* Backward Difference Formula, order 3, with extrapolation */
 class extbdf3: public timeStepperBase_t {
 protected:
-  int Nstages;
+  static constexpr int Nstages{3};
   int shiftIndex;
 
   memory<dfloat> extbdf_a;
@@ -391,7 +391,7 @@ public:
 /* Backward Difference Formula, order 3, with subcycling */
 class ssbdf3: public timeStepperBase_t {
 protected:
-  int Nstages;
+  static constexpr int Nstages{3};
   int shiftIndex;
 
   memory<dfloat> ssbdf_b;
@@ -420,7 +420,7 @@ class mrab3: public timeStepperBase_t {
 protected:
   mesh_t mesh;
 
-  int Nstages;
+  static constexpr int Nstages{3};
   int Nlevels;
   int Nfields;
 
@@ -453,7 +453,7 @@ class mrsaab3: public timeStepperBase_t {
 protected:
   mesh_t mesh;
 
-  int Nstages;
+  static constexpr int Nstages{3};
   int Nlevels;
   int Nfields;
 

--- a/libs/timeStepper/timeStepperAB3.cpp
+++ b/libs/timeStepper/timeStepperAB3.cpp
@@ -38,7 +38,7 @@ ab3::ab3(dlong Nelements, dlong NhaloElements,
   timeStepperBase_t(Nelements, NhaloElements, Np, Nfields,
                     _platform, _comm) {
 
-  Nstages = 3;
+  //Nstages = 3;
   shiftIndex = 0;
 
   memory<dfloat> rhsq(Nstages*N,0.0);

--- a/libs/timeStepper/timeStepperEXTBDF3.cpp
+++ b/libs/timeStepper/timeStepperEXTBDF3.cpp
@@ -38,7 +38,7 @@ extbdf3::extbdf3(dlong Nelements, dlong NhaloElements,
   timeStepperBase_t(Nelements, NhaloElements, Np, Nfields,
                     _platform, _comm) {
 
-  Nstages = 3;
+  //Nstages = 3;
   shiftIndex = 0;
 
   memory<dfloat> qn(Nstages*N, 0.0);

--- a/libs/timeStepper/timeStepperMRAB3.cpp
+++ b/libs/timeStepper/timeStepperMRAB3.cpp
@@ -40,7 +40,7 @@ mrab3::mrab3(dlong Nelements, dlong NhaloElements,
   Nlevels(mesh.mrNlevels),
   Nfields(_Nfields) {
 
-  Nstages = 3;
+  //Nstages = 3;
 
   memory<dfloat> rhsq0(N, 0.0);
   o_rhsq0 = platform.malloc<dfloat>(rhsq0);

--- a/libs/timeStepper/timeStepperMRSAAB3.cpp
+++ b/libs/timeStepper/timeStepperMRSAAB3.cpp
@@ -47,7 +47,7 @@ mrsaab3::mrsaab3(dlong _Nelements, dlong _NhaloElements,
   lambda.malloc(Nfields);
   lambda.copyFrom(_lambda);
 
-  Nstages = 3;
+  //Nstages = 3;
 
   memory<dfloat> rhsq0(N, 0.0);
   o_rhsq0 = platform.malloc<dfloat>(rhsq0);

--- a/libs/timeStepper/timeStepperSAAB3.cpp
+++ b/libs/timeStepper/timeStepperSAAB3.cpp
@@ -48,7 +48,7 @@ saab3::saab3(dlong _Nelements, dlong _NhaloElements,
   lambda.malloc(Nfields);
   lambda.copyFrom(_lambda);
 
-  Nstages = 3;
+  //Nstages = 3;
   shiftIndex = 0;
 
   o_rhsq = platform.malloc<dfloat>(Nstages*N);

--- a/libs/timeStepper/timeStepperSARK4.cpp
+++ b/libs/timeStepper/timeStepperSARK4.cpp
@@ -49,7 +49,7 @@ sark4::sark4(dlong _Nelements, dlong _NhaloElements,
   lambda.malloc(Nfields);
   lambda.copyFrom(_lambda);
 
-  Nrk = 5;
+  //Nrk = 5;
   order = 4;
   embeddedOrder = 3;
 

--- a/libs/timeStepper/timeStepperSARK5.cpp
+++ b/libs/timeStepper/timeStepperSARK5.cpp
@@ -49,7 +49,7 @@ sark5::sark5(dlong _Nelements, dlong _NhaloElements,
   lambda.malloc(Nfields);
   lambda.copyFrom(_lambda);
 
-  Nrk = 7; //number of stages
+  //Nrk = 7; //number of stages
   order = 5;
   embeddedOrder = 4;
 

--- a/libs/timeStepper/timeStepperSSBDF3.cpp
+++ b/libs/timeStepper/timeStepperSSBDF3.cpp
@@ -38,7 +38,7 @@ ssbdf3::ssbdf3(dlong Nelements, dlong NhaloElements,
   timeStepperBase_t(Nelements, NhaloElements, Np, Nfields,
                     _platform, _comm) {
 
-  Nstages = 3;
+  //Nstages = 3;
   shiftIndex = 0;
 
   o_qn   = platform.malloc<dfloat>(Nstages*N); //q history


### PR DESCRIPTION
Parameters such as Nrk and Nstages are declared as variables in the timestepper library with values assigned in the member functions. And these variables are used to define array sizes at runtime which gives compilation errors while building with Intel compilers. 

To resolve the issue, these parameters are modified and defined as static constexpr with fixed values in the timeStepper.hpp header file. 