### PR TITLE
Timestepper cleanup

### DIFF
--- a/include/timeStepper.hpp
+++ b/include/timeStepper.hpp
@@ -454,6 +454,7 @@ protected:
 
   memory<dfloat> mrdt;
   deviceMemory<dfloat> o_mrdt;
+  deviceMemory<dfloat> o_zeros;
 
   memory<dfloat> ab_a, ab_b;
   deviceMemory<dfloat> o_ab_a, o_ab_b;
@@ -489,6 +490,7 @@ protected:
 
   memory<dfloat> mrdt;
   deviceMemory<dfloat> o_mrdt;
+  deviceMemory<dfloat> o_zeros;
 
   pinnedMemory<dfloat> h_saab_x, h_saab_a, h_saab_b;
   deviceMemory<dfloat> o_saab_x, o_saab_a, o_saab_b;
@@ -897,6 +899,7 @@ private:
 
   memory<dfloat> mrdt;
   deviceMemory<dfloat> o_mrdt;
+  deviceMemory<dfloat> o_zeros;
 
   memory<dfloat> ab_a, ab_b;
   deviceMemory<dfloat> o_ab_a, o_ab_b;
@@ -941,6 +944,7 @@ private:
 
   memory<dfloat> mrdt;
   deviceMemory<dfloat> o_mrdt;
+  deviceMemory<dfloat> o_zeros;
 
   pinnedMemory<dfloat> h_saab_x, h_saab_a, h_saab_b;
   deviceMemory<dfloat> o_saab_x, o_saab_a, o_saab_b;

--- a/include/timeStepper.hpp
+++ b/include/timeStepper.hpp
@@ -27,6 +27,7 @@ SOFTWARE.
 #ifndef TIMESTEPPER_HPP
 #define TIMESTEPPER_HPP
 
+#include <optional>
 #include "core.hpp"
 #include "settings.hpp"
 #include "mesh.hpp"
@@ -37,7 +38,6 @@ namespace libp {
 //forward declare
 namespace TimeStepper {
   class timeStepperBase_t;
-  class pmlTimeStepperBase_t;
 }
 
 /* General TimeStepper object*/
@@ -51,7 +51,14 @@ class timeStepper_t {
     ts = std::make_shared<Stepper>(args...);
   }
 
-  void Run(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat start, dfloat end);
+  void Run(solver_t& solver,
+           deviceMemory<dfloat>& o_q,
+           dfloat start, dfloat end);
+
+  void RunWithPml(solver_t& solver,
+                  deviceMemory<dfloat>& o_q,
+                  deviceMemory<dfloat>& o_pmlq,
+                  dfloat start, dfloat end);
 
   void SetTimeStep(dfloat dt_);
 
@@ -61,34 +68,6 @@ class timeStepper_t {
 
  private:
   std::shared_ptr<TimeStepper::timeStepperBase_t> ts=nullptr;
-
-  void assertInitialized();
-};
-
-/* General PML TimeStepper object*/
-class pmlTimeStepper_t {
- public:
-  pmlTimeStepper_t() = default;
-
-  /*Generic setup. Create a Stepper object and wrap it in a shared_ptr*/
-  template<class Stepper, class... Args>
-  void Setup(Args&& ... args) {
-    ts = std::make_shared<Stepper>(args...);
-  }
-
-  void Run(solver_t& solver,
-           deviceMemory<dfloat>& o_q,
-           deviceMemory<dfloat>& o_pmlq,
-           dfloat start, dfloat end);
-
-  void SetTimeStep(dfloat dt_);
-
-  dfloat GetTimeStep();
-
-  dfloat GetGamma();
-
- private:
-  std::shared_ptr<TimeStepper::pmlTimeStepperBase_t> ts=nullptr;
 
   void assertInitialized();
 };
@@ -103,18 +82,23 @@ public:
 
   dlong N;
   dlong Nhalo;
+  dlong Npml;
 
   dfloat dt;
 
-  timeStepperBase_t(dlong Nelements, dlong NhaloElements,
-                    int Np, int Nfields,
+  timeStepperBase_t(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
+                    int Np, int Nfields, int Npmlfields,
                     platform_t& _platform, comm_t _comm):
     platform(_platform),
     comm(_comm),
     N(Nelements*Np*Nfields),
-    Nhalo(NhaloElements*Np*Nfields) {}
+    Nhalo(NhaloElements*Np*Nfields),
+    Npml(NpmlElements*Np*Npmlfields) {}
 
-  virtual void Run(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat start, dfloat end)=0;
+  virtual void Run(solver_t& solver,
+                   deviceMemory<dfloat> o_q,
+                   std::optional<deviceMemory<dfloat>> o_pmlq,
+                   dfloat start, dfloat end)=0;
 
   void SetTimeStep(dfloat dt_) {dt = dt_;};
 
@@ -136,456 +120,32 @@ protected:
   deviceMemory<dfloat> o_ab_a;
 
   deviceMemory<dfloat> o_rhsq;
-
-  kernel_t updateKernel;
-
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
-
-public:
-  ab3(dlong Nelements, dlong NhaloElements,
-      int Np, int Nfields,
-      platform_t& _platform, comm_t _comm);
-
-  void Run(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat start, dfloat end);
-};
-
-/* Low-Storage Explicit Runge-Kutta, order 4 */
-class lserk4: public timeStepperBase_t {
-protected:
-  int Nrk;
-  memory<dfloat> rka, rkb, rkc;
-
-  deviceMemory<dfloat> o_rhsq;
-  deviceMemory<dfloat> o_resq;
-
-  deviceMemory<dfloat> o_saveq;
-
-  kernel_t updateKernel;
-
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt);
-
-public:
-  lserk4(dlong Nelements, dlong NhaloElements,
-         int Np, int Nfields,
-         platform_t& _platform, comm_t _comm);
-
-  void Run(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat start, dfloat end);
-};
-
-/* Dormand-Prince method */
-/* Explict Runge-Kutta, order 5 with embedded order 4 and adaptive time-stepping */
-class dopri5: public timeStepperBase_t {
-protected:
-  int Nrk;
-
-  dlong Nblock;
-
-  memory<dfloat> rkC, rkA, rkE;
-  deviceMemory<dfloat> o_rkA, o_rkE;
-
-  deviceMemory<dfloat> o_errtmp;
-  pinnedMemory<dfloat> h_errtmp;
-
-  deviceMemory<dfloat> o_rhsq;
-  deviceMemory<dfloat> o_rkq;
-  deviceMemory<dfloat> o_rkrhsq;
-  deviceMemory<dfloat> o_rkerr;
-
-  deviceMemory<dfloat> o_saveq;
-
-
-  kernel_t rkUpdateKernel;
-  kernel_t rkStageKernel;
-  kernel_t rkErrorEstimateKernel;
-
-  dfloat dtMIN; //minumum allowed timestep
-  dfloat ATOL;  //absolute error tolerance
-  dfloat RTOL;  //relative error tolerance
-  dfloat safe;   //safety factor
-
-  //error control parameters
-  dfloat beta;
-  dfloat factor1;
-  dfloat factor2;
-
-  dfloat exp1;
-  dfloat invfactor1;
-  dfloat invfactor2;
-  dfloat facold;
-  dfloat sqrtinvNtotal;
-
-  void Backup(deviceMemory<dfloat> &o_Q);
-  void Restore(deviceMemory<dfloat> &o_Q);
-  void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq);
-
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt);
-
-  dfloat Estimater(deviceMemory<dfloat>& o_q);
-
-public:
-  dopri5(dlong Nelements, dlong NhaloElements,
-         int Np, int Nfields,
-         platform_t& _platform, comm_t _comm);
-
-  void Run(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat start, dfloat end);
-};
-
-/* Semi-Analytic Adams-Bashforth, order 3 */
-class saab3: public timeStepperBase_t {
-protected:
-  static constexpr int Nstages{3};
-  int shiftIndex;
-
-  int Np, Nfields;
-  dlong Nblock, Nelements, NhaloElements;
-
-  memory<dfloat> lambda;
-
-  pinnedMemory<dfloat> h_saab_x, h_saab_a;
-  deviceMemory<dfloat> o_saab_x, o_saab_a;
-
-  deviceMemory<dfloat> o_rhsq;
-
-  kernel_t updateKernel;
-
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
-
-public:
-  saab3(dlong _Nelements, dlong _NhaloElements,
-        int _Np, int _Nfields,
-        memory<dfloat> _lambda,
-        platform_t& _platform, comm_t _comm);
-
-  void Run(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat start, dfloat end);
-};
-
-/* Semi-Analytic Explict Runge-Kutta, order 4 with embedded order 3 and adaptive time-stepping */
-class sark4: public timeStepperBase_t {
-protected:
-  static constexpr int Nrk{5};
-  int order, embeddedOrder;
-
-  int Np, Nfields;
-  dlong Nblock, Nelements, NhaloElements;
-
-  memory<dfloat> lambda;
-
-  memory<dfloat> rkC;
-  deviceMemory<dfloat> o_rkX, o_rkA, o_rkE;
-  pinnedMemory<dfloat> h_rkX, h_rkA, h_rkE;
-
-  deviceMemory<dfloat> o_rhsq;
-  deviceMemory<dfloat> o_rkq;
-  deviceMemory<dfloat> o_rkrhsq;
-  deviceMemory<dfloat> o_rkerr;
-
-  deviceMemory<dfloat> o_saveq;
-
-  deviceMemory<dfloat> o_errtmp;
-  pinnedMemory<dfloat> h_errtmp;
-
-  kernel_t rkUpdateKernel;
-  kernel_t rkStageKernel;
-  kernel_t rkErrorEstimateKernel;
-
-  dfloat dtMIN; //minumum allowed timestep
-  dfloat ATOL;  //absolute error tolerance
-  dfloat RTOL;  //relative error tolerance
-  dfloat safe;   //safety factor
-
-  //error control parameters
-  dfloat beta;
-  dfloat factor1;
-  dfloat factor2;
-
-  dfloat exp1;
-  dfloat invfactor1;
-  dfloat invfactor2;
-  dfloat facold;
-  dfloat sqrtinvNtotal;
-
-  void Backup(deviceMemory<dfloat> &o_Q);
-  void Restore(deviceMemory<dfloat> &o_Q);
-  void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq);
-
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt);
-
-  dfloat Estimater(deviceMemory<dfloat>& o_q);
-
-public:
-  sark4(dlong _Nelements, dlong _NhaloElements,
-        int _Np, int _Nfields,
-        memory<dfloat> _lambda,
-        platform_t& _platform, comm_t _comm);
-
-  void Run(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat start, dfloat end);
-};
-
-/* Semi-Analytic Explict Runge-Kutta, order 5 with embedded order 4 and adaptive time-stepping */
-class sark5: public timeStepperBase_t {
-protected:
-  static constexpr int Nrk{7};
-  int order, embeddedOrder;
-
-  int Np, Nfields;
-  dlong Nblock, Nelements, NhaloElements;
-
-  memory<dfloat> lambda;
-
-  memory<dfloat> rkC;
-  deviceMemory<dfloat> o_rkX, o_rkA, o_rkE;
-  pinnedMemory<dfloat> h_rkX, h_rkA, h_rkE;
-
-
-  deviceMemory<dfloat> o_rhsq;
-  deviceMemory<dfloat> o_rkq;
-  deviceMemory<dfloat> o_rkrhsq;
-  deviceMemory<dfloat> o_rkerr;
-
-  deviceMemory<dfloat> o_saveq;
-
-  deviceMemory<dfloat> o_errtmp;
-  pinnedMemory<dfloat> h_errtmp;
-
-  kernel_t rkUpdateKernel;
-  kernel_t rkStageKernel;
-  kernel_t rkErrorEstimateKernel;
-
-  dfloat dtMIN; //minumum allowed timestep
-  dfloat ATOL;  //absolute error tolerance
-  dfloat RTOL;  //relative error tolerance
-  dfloat safe;   //safety factor
-
-  //error control parameters
-  dfloat beta;
-  dfloat factor1;
-  dfloat factor2;
-
-  dfloat exp1;
-  dfloat invfactor1;
-  dfloat invfactor2;
-  dfloat facold;
-  dfloat sqrtinvNtotal;
-
-  void Backup(deviceMemory<dfloat> &o_Q);
-  void Restore(deviceMemory<dfloat> &o_Q);
-  void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq);
-
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt);
-
-  dfloat Estimater(deviceMemory<dfloat>& o_q);
-
-public:
-  sark5(dlong _Nelements, dlong _NhaloElements,
-        int _Np, int _Nfields,
-        memory<dfloat> _lambda,
-        platform_t& _platform, comm_t _comm);
-
-  void Run(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat start, dfloat end);
-};
-
-/* Backward Difference Formula, order 3, with extrapolation */
-class extbdf3: public timeStepperBase_t {
-protected:
-  static constexpr int Nstages{3};
-  int shiftIndex;
-
-  memory<dfloat> extbdf_a;
-  memory<dfloat> extbdf_b;
-  deviceMemory<dfloat> o_extbdf_a;
-  deviceMemory<dfloat> o_extbdf_b;
-
-  deviceMemory<dfloat> o_rhs;
-  deviceMemory<dfloat> o_qn;
-  deviceMemory<dfloat> o_F;
-
-  kernel_t rhsKernel;
-
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
-
-public:
-  extbdf3(dlong Nelements, dlong NhaloElements,
-      int Np, int Nfields,
-      platform_t& _platform, comm_t _comm);
-
-  dfloat GetGamma();
-
-  void Run(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat start, dfloat end);
-};
-
-/* Backward Difference Formula, order 3, with subcycling */
-class ssbdf3: public timeStepperBase_t {
-protected:
-  static constexpr int Nstages{3};
-  int shiftIndex;
-
-  memory<dfloat> ssbdf_b;
-  deviceMemory<dfloat> o_ssbdf_b;
-
-  deviceMemory<dfloat> o_rhs;
-  deviceMemory<dfloat> o_qn;
-  deviceMemory<dfloat> o_qhat;
-
-  kernel_t rhsKernel;
-
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
-
-public:
-  ssbdf3(dlong Nelements, dlong NhaloElements,
-      int Np, int Nfields,
-      platform_t& _platform, comm_t _comm);
-
-  dfloat GetGamma();
-
-  void Run(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat start, dfloat end);
-};
-
-/* Multi-rate Adams-Bashforth, order 3 */
-class mrab3: public timeStepperBase_t {
-protected:
-  mesh_t mesh;
-
-  static constexpr int Nstages{3};
-  int Nlevels;
-  int Nfields;
-
-  deviceMemory<int> o_shiftIndex;
-  pinnedMemory<int> h_shiftIndex;
-
-  memory<dfloat> mrdt;
-  deviceMemory<dfloat> o_mrdt;
-  deviceMemory<dfloat> o_zeros;
-
-  memory<dfloat> ab_a, ab_b;
-  deviceMemory<dfloat> o_ab_a, o_ab_b;
-
-  deviceMemory<dfloat> o_rhsq0, o_rhsq, o_fQM;
-
-  kernel_t updateKernel;
-  kernel_t traceUpdateKernel;
-
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
-
-public:
-  mrab3(dlong _Nelements, dlong _NhaloElements,
-         int _Np, int _Nfields,
-         platform_t& _platform, mesh_t& _mesh);
-
-  void Run(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat start, dfloat end);
-};
-
-/* Multi-rate Semi-Analytic Adams-Bashforth, order 3 */
-class mrsaab3: public timeStepperBase_t {
-protected:
-  mesh_t mesh;
-
-  static constexpr int Nstages{3};
-  int Nlevels;
-  int Nfields;
-
-  memory<dfloat> lambda;
-
-  deviceMemory<int> o_shiftIndex;
-  pinnedMemory<int> h_shiftIndex;
-
-  memory<dfloat> mrdt;
-  deviceMemory<dfloat> o_mrdt;
-  deviceMemory<dfloat> o_zeros;
-
-  pinnedMemory<dfloat> h_saab_x, h_saab_a, h_saab_b;
-  deviceMemory<dfloat> o_saab_x, o_saab_a, o_saab_b;
-
-  deviceMemory<dfloat> o_rhsq0, o_rhsq, o_fQM;
-
-  kernel_t updateKernel;
-  kernel_t traceUpdateKernel;
-
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
-
-public:
-  mrsaab3(dlong _Nelements, dlong _NhaloElements,
-         int _Np, int _Nfields,
-         memory<dfloat> _lambda,
-         platform_t& _platform, mesh_t& _mesh);
-
-  void Init();
-  void Run(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat start, dfloat end);
-};
-
-
-/**************************************************/
-/* Derived Time Integrators which step PML fields */
-/**************************************************/
-
-//base pml time stepper class
-class pmlTimeStepperBase_t {
-public:
-  platform_t platform;
-  comm_t comm;
-
-  dlong N;
-  dlong Nhalo;
-  dlong Npml;
-
-  dfloat dt;
-
-  pmlTimeStepperBase_t(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
-                    int Np, int Nfields, int Npmlfields,
-                    platform_t& _platform, comm_t _comm):
-    platform(_platform),
-    comm(_comm),
-    N(Nelements*Np*Nfields),
-    Nhalo(NhaloElements*Np*Nfields),
-    Npml(NpmlElements*Np*Npmlfields) {}
-
-  virtual void Run(solver_t& solver,
-                   deviceMemory<dfloat>& o_q,
-                   deviceMemory<dfloat>& o_pmlq,
-                   dfloat start, dfloat end) = 0;
-
-  void SetTimeStep(dfloat dt_) {dt = dt_;};
-
-  dfloat GetTimeStep() {return dt;};
-
-  virtual dfloat GetGamma() {
-    LIBP_FORCE_ABORT("GetGamma() not available in this Timestepper");
-    return 0.0;
-  }
-};
-
-/* Adams Bashforth, order 3 */
-class ab3_pml: public pmlTimeStepperBase_t {
-private:
-  static constexpr int Nstages{3};
-  int shiftIndex;
-
-  memory<dfloat> ab_a;
-  deviceMemory<dfloat> o_ab_a;
-
-  deviceMemory<dfloat> o_rhsq;
   deviceMemory<dfloat> o_rhspmlq;
 
   kernel_t updateKernel;
 
   void Step(solver_t& solver,
-            deviceMemory<dfloat>& o_q,
-            deviceMemory<dfloat>& o_pmlq,
+            deviceMemory<dfloat> o_q,
+            std::optional<deviceMemory<dfloat>> o_pmlq,
             dfloat time, dfloat dt, int order);
 
 public:
-  ab3_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
-          int Np, int Nfields, int Npmlfields,
-          platform_t& _platform, comm_t _comm);
+  ab3(dlong Nelements, dlong NhaloElements,
+      int Np, int Nfields,
+      platform_t& _platform, comm_t _comm);
+  ab3(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
+      int Np, int Nfields, int Npmlfields,
+      platform_t& _platform, comm_t _comm);
 
   void Run(solver_t& solver,
-           deviceMemory<dfloat>& o_q,
-           deviceMemory<dfloat>& o_pmlq,
+           deviceMemory<dfloat> o_q,
+           std::optional<deviceMemory<dfloat>> o_pmlq,
            dfloat start, dfloat end);
 };
 
 /* Low-Storage Explicit Runge-Kutta, order 4 */
-class lserk4_pml: public pmlTimeStepperBase_t {
-private:
+class lserk4: public timeStepperBase_t {
+protected:
   int Nrk;
   memory<dfloat> rka, rkb, rkc;
 
@@ -600,25 +160,28 @@ private:
   kernel_t updateKernel;
 
   void Step(solver_t& solver,
-            deviceMemory<dfloat>& o_q,
-            deviceMemory<dfloat>& o_pmlq,
+            deviceMemory<dfloat> o_q,
+            std::optional<deviceMemory<dfloat>> o_pmlq,
             dfloat time, dfloat dt);
 
 public:
-  lserk4_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
-            int Np, int Nfields, int Npmlfields,
-            platform_t& _platform, comm_t _comm);
+  lserk4(dlong Nelements, dlong NhaloElements,
+         int Np, int Nfields,
+         platform_t& _platform, comm_t _comm);
+  lserk4(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
+         int Np, int Nfields, int Npmlfields,
+         platform_t& _platform, comm_t _comm);
 
   void Run(solver_t& solver,
-           deviceMemory<dfloat>& o_q,
-           deviceMemory<dfloat>& o_pmlq,
+           deviceMemory<dfloat> o_q,
+           std::optional<deviceMemory<dfloat>> o_pmlq,
            dfloat start, dfloat end);
 };
 
 /* Dormand-Prince method */
 /* Explict Runge-Kutta, order 5 with embedded order 4 and adaptive time-stepping */
-class dopri5_pml: public pmlTimeStepperBase_t {
-private:
+class dopri5: public timeStepperBase_t {
+protected:
   int Nrk;
 
   dlong Nblock;
@@ -663,33 +226,30 @@ private:
   dfloat facold;
   dfloat sqrtinvNtotal;
 
-  void Backup(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq);
-  void Restore(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq);
-  void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq,
-                  deviceMemory<dfloat> &o_pmlq, deviceMemory<dfloat> &o_rpmlq);
-
   void Step(solver_t& solver,
-            deviceMemory<dfloat>& o_q,
-            deviceMemory<dfloat>& o_pmlq,
+            deviceMemory<dfloat> o_q,
+            std::optional<deviceMemory<dfloat>> o_pmlq,
             dfloat time, dfloat dt);
 
   dfloat Estimater(deviceMemory<dfloat>& o_q);
 
 public:
-  dopri5_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
-            int Np, int Nfields, int Npmlfields,
-            platform_t& _platform, comm_t _comm);
+  dopri5(dlong Nelements, dlong NhaloElements,
+         int Np, int Nfields,
+         platform_t& _platform, comm_t _comm);
+  dopri5(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
+         int Np, int Nfields, int Npmlfields,
+         platform_t& _platform, comm_t _comm);
 
   void Run(solver_t& solver,
-           deviceMemory<dfloat>& o_q,
-           deviceMemory<dfloat>& o_pmlq,
+           deviceMemory<dfloat> o_q,
+           std::optional<deviceMemory<dfloat>> o_pmlq,
            dfloat start, dfloat end);
 };
 
 /* Semi-Analytic Adams-Bashforth, order 3 */
-// Note: PML fields are not stepped Semi-Analytically
-class saab3_pml: public pmlTimeStepperBase_t {
-private:
+class saab3: public timeStepperBase_t {
+protected:
   static constexpr int Nstages{3};
   int shiftIndex;
 
@@ -711,26 +271,31 @@ private:
   kernel_t pmlUpdateKernel;
 
   void Step(solver_t& solver,
-            deviceMemory<dfloat>& o_q,
-            deviceMemory<dfloat>& o_pmlq,
+            deviceMemory<dfloat> o_q,
+            std::optional<deviceMemory<dfloat>> o_pmlq,
             dfloat time, dfloat dt, int order);
 
+  void UpdateCoefficients();
+
 public:
-  saab3_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
-            int Np, int Nfields, int _Npmlfields,
-            memory<dfloat> _lambda,
-            platform_t& _platform, comm_t _comm);
+  saab3(dlong _Nelements, dlong _NhaloElements,
+        int _Np, int _Nfields,
+        memory<dfloat> _lambda,
+        platform_t& _platform, comm_t _comm);
+  saab3(dlong _Nelements, dlong NpmlElements, dlong _NhaloElements,
+        int _Np, int _Nfields, int Npmlfields,
+        memory<dfloat> _lambda,
+        platform_t& _platform, comm_t _comm);
 
   void Run(solver_t& solver,
-           deviceMemory<dfloat>& o_q,
-           deviceMemory<dfloat>& o_pmlq,
+           deviceMemory<dfloat> o_q,
+           std::optional<deviceMemory<dfloat>> o_pmlq,
            dfloat start, dfloat end);
 };
 
 /* Semi-Analytic Explict Runge-Kutta, order 4 with embedded order 3 and adaptive time-stepping */
-// Note: PML fields are not stepped Semi-Analytically
-class sark4_pml: public pmlTimeStepperBase_t {
-private:
+class sark4: public timeStepperBase_t {
+protected:
   static constexpr int Nrk{5};
   int order, embeddedOrder;
 
@@ -782,33 +347,35 @@ private:
   dfloat facold;
   dfloat sqrtinvNtotal;
 
-  void Backup(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq);
-  void Restore(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq);
-  void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq,
-                  deviceMemory<dfloat> &o_pmlq, deviceMemory<dfloat> &o_rpmlq);
 
   void Step(solver_t& solver,
-            deviceMemory<dfloat>& o_q,
-            deviceMemory<dfloat>& o_pmlq,
+            deviceMemory<dfloat> o_q,
+            std::optional<deviceMemory<dfloat>> o_pmlq,
             dfloat time, dfloat dt);
 
   dfloat Estimater(deviceMemory<dfloat>& o_q);
 
+  void UpdateCoefficients();
+
 public:
-  sark4_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
-            int Np, int Nfields, int _Npmlfields,
-            memory<dfloat> _lambda, platform_t& _platform, comm_t _comm);
+  sark4(dlong Nelements, dlong NhaloElements,
+        int Np, int Nfields,
+        memory<dfloat> _lambda,
+        platform_t& _platform, comm_t _comm);
+  sark4(dlong _Nelements, dlong NpmlElements, dlong _NhaloElements,
+        int _Np, int _Nfields, int _Npmlfields,
+        memory<dfloat> _lambda,
+        platform_t& _platform, comm_t _comm);
 
   void Run(solver_t& solver,
-           deviceMemory<dfloat>& o_q,
-           deviceMemory<dfloat>& o_pmlq,
+           deviceMemory<dfloat> o_q,
+           std::optional<deviceMemory<dfloat>> o_pmlq,
            dfloat start, dfloat end);
 };
 
 /* Semi-Analytic Explict Runge-Kutta, order 5 with embedded order 4 and adaptive time-stepping */
-// Note: PML fields are not stepped Semi-Analytically
-class sark5_pml: public pmlTimeStepperBase_t {
-private:
+class sark5: public timeStepperBase_t {
+protected:
   static constexpr int Nrk{7};
   int order, embeddedOrder;
 
@@ -861,32 +428,100 @@ private:
   dfloat facold;
   dfloat sqrtinvNtotal;
 
-  void Backup(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq);
-  void Restore(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq);
-  void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq,
-                  deviceMemory<dfloat> &o_pmlq, deviceMemory<dfloat> &o_rpmlq);
-
-  void Step(solver_t& solver,
-            deviceMemory<dfloat>& o_q,
-            deviceMemory<dfloat>& o_pmlq,
+   void Step(solver_t& solver,
+            deviceMemory<dfloat> o_q,
+            std::optional<deviceMemory<dfloat>> o_pmlq,
             dfloat time, dfloat dt);
 
   dfloat Estimater(deviceMemory<dfloat>& o_q);
 
+  void UpdateCoefficients();
+
 public:
-  sark5_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
-            int Np, int Nfields, int _Npmlfields,
-            memory<dfloat> _lambda, platform_t& _platform, comm_t _comm);
+  sark5(dlong Nelements, dlong NhaloElements,
+        int Np, int Nfields,
+        memory<dfloat> _lambda,
+        platform_t& _platform, comm_t _comm);
+  sark5(dlong _Nelements, dlong NpmlElements, dlong _NhaloElements,
+        int _Np, int _Nfields, int Npmlfields,
+        memory<dfloat> _lambda,
+        platform_t& _platform, comm_t _comm);
 
   void Run(solver_t& solver,
-           deviceMemory<dfloat>& o_q,
-           deviceMemory<dfloat>& o_pmlq,
+           deviceMemory<dfloat> o_q,
+           std::optional<deviceMemory<dfloat>> o_pmlq,
+           dfloat start, dfloat end);
+};
+
+/* Backward Difference Formula, order 3, with extrapolation */
+class extbdf3: public timeStepperBase_t {
+protected:
+  static constexpr int Nstages{3};
+  int shiftIndex;
+
+  memory<dfloat> extbdf_a;
+  memory<dfloat> extbdf_b;
+  deviceMemory<dfloat> o_extbdf_a;
+  deviceMemory<dfloat> o_extbdf_b;
+
+  deviceMemory<dfloat> o_rhs;
+  deviceMemory<dfloat> o_qn;
+  deviceMemory<dfloat> o_F;
+
+  kernel_t rhsKernel;
+
+  void Step(solver_t& solver,
+            deviceMemory<dfloat> o_q,
+            dfloat time, dfloat dt, int order);
+
+public:
+  extbdf3(dlong Nelements, dlong NhaloElements,
+          int Np, int Nfields,
+          platform_t& _platform, comm_t _comm);
+
+  dfloat GetGamma();
+
+  void Run(solver_t& solver,
+           deviceMemory<dfloat> o_q,
+           std::optional<deviceMemory<dfloat>> o_pmlq,
+           dfloat start, dfloat end);
+};
+
+/* Backward Difference Formula, order 3, with subcycling */
+class ssbdf3: public timeStepperBase_t {
+protected:
+  static constexpr int Nstages{3};
+  int shiftIndex;
+
+  memory<dfloat> ssbdf_b;
+  deviceMemory<dfloat> o_ssbdf_b;
+
+  deviceMemory<dfloat> o_rhs;
+  deviceMemory<dfloat> o_qn;
+  deviceMemory<dfloat> o_qhat;
+
+  kernel_t rhsKernel;
+
+  void Step(solver_t& solver,
+            deviceMemory<dfloat> o_q,
+            dfloat time, dfloat dt, int order);
+
+public:
+  ssbdf3(dlong Nelements, dlong NhaloElements,
+      int Np, int Nfields,
+      platform_t& _platform, comm_t _comm);
+
+  dfloat GetGamma();
+
+  void Run(solver_t& solver,
+           deviceMemory<dfloat> o_q,
+           std::optional<deviceMemory<dfloat>> o_pmlq,
            dfloat start, dfloat end);
 };
 
 /* Multi-rate Adams-Bashforth, order 3 */
-class mrab3_pml: public pmlTimeStepperBase_t {
-private:
+class mrab3: public timeStepperBase_t {
+protected:
   mesh_t mesh;
 
   static constexpr int Nstages{3};
@@ -912,24 +547,27 @@ private:
   kernel_t traceUpdateKernel;
 
   void Step(solver_t& solver,
-            deviceMemory<dfloat>& o_q,
-            deviceMemory<dfloat>& o_pmlq,
+            deviceMemory<dfloat> o_q,
+            std::optional<deviceMemory<dfloat>> o_pmlq,
             dfloat time, dfloat dt, int order);
 
 public:
-  mrab3_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
-            int Np, int Nfields, int _Npmlfields, platform_t& _platform, mesh_t& _mesh);
+  mrab3(dlong Nelements, dlong NhaloElements,
+        int _Np, int _Nfields,
+        platform_t& _platform, mesh_t& _mesh);
+  mrab3(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
+        int _Np, int _Nfields, int _Npmlfields,
+        platform_t& _platform, mesh_t& _mesh);
 
   void Run(solver_t& solver,
-           deviceMemory<dfloat>& o_q,
-           deviceMemory<dfloat>& o_pmlq,
+           deviceMemory<dfloat> o_q,
+           std::optional<deviceMemory<dfloat>> o_pmlq,
            dfloat start, dfloat end);
 };
 
 /* Multi-rate Semi-Analytic Adams-Bashforth, order 3 */
-// Note: PML fields are not stepped Semi-Analytically
-class mrsaab3_pml: public pmlTimeStepperBase_t {
-private:
+class mrsaab3: public timeStepperBase_t {
+protected:
   mesh_t mesh;
 
   static constexpr int Nstages{3};
@@ -959,18 +597,25 @@ private:
   kernel_t traceUpdateKernel;
 
   void Step(solver_t& solver,
-            deviceMemory<dfloat>& o_q,
-            deviceMemory<dfloat>& o_pmlq,
+            deviceMemory<dfloat> o_q,
+            std::optional<deviceMemory<dfloat>> o_pmlq,
             dfloat time, dfloat dt, int order);
 
+  void UpdateCoefficients();
+
 public:
-  mrsaab3_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
-            int Np, int Nfields, int _Npmlfields,
-            memory<dfloat> _lambda, platform_t& _platform, mesh_t& _mesh);
+  mrsaab3(dlong _Nelements, dlong _NhaloElements,
+          int _Np, int _Nfields,
+          memory<dfloat> _lambda,
+          platform_t& _platform, mesh_t& _mesh);
+  mrsaab3(dlong _Nelements, dlong NpmlElements, dlong _NhaloElements,
+          int _Np, int _Nfields, int _Npmlfields,
+          memory<dfloat> _lambda,
+          platform_t& _platform, mesh_t& _mesh);
 
   void Run(solver_t& solver,
-           deviceMemory<dfloat>& o_q,
-           deviceMemory<dfloat>& o_pmlq,
+           deviceMemory<dfloat> o_q,
+           std::optional<deviceMemory<dfloat>> o_pmlq,
            dfloat start, dfloat end);
 };
 

--- a/include/timeStepper.hpp
+++ b/include/timeStepper.hpp
@@ -35,7 +35,10 @@ SOFTWARE.
 namespace libp {
 
 //forward declare
-namespace TimeStepper { class timeStepperBase_t; }
+namespace TimeStepper {
+  class timeStepperBase_t;
+  class pmlTimeStepperBase_t;
+}
 
 /* General TimeStepper object*/
 class timeStepper_t {
@@ -58,6 +61,34 @@ class timeStepper_t {
 
  private:
   std::shared_ptr<TimeStepper::timeStepperBase_t> ts=nullptr;
+
+  void assertInitialized();
+};
+
+/* General PML TimeStepper object*/
+class pmlTimeStepper_t {
+ public:
+  pmlTimeStepper_t() = default;
+
+  /*Generic setup. Create a Stepper object and wrap it in a shared_ptr*/
+  template<class Stepper, class... Args>
+  void Setup(Args&& ... args) {
+    ts = std::make_shared<Stepper>(args...);
+  }
+
+  void Run(solver_t& solver,
+           deviceMemory<dfloat>& o_q,
+           deviceMemory<dfloat>& o_pmlq,
+           dfloat start, dfloat end);
+
+  void SetTimeStep(dfloat dt_);
+
+  dfloat GetTimeStep();
+
+  dfloat GetGamma();
+
+ private:
+  std::shared_ptr<TimeStepper::pmlTimeStepperBase_t> ts=nullptr;
 
   void assertInitialized();
 };
@@ -108,7 +139,7 @@ protected:
 
   kernel_t updateKernel;
 
-  virtual void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
+  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
 
 public:
   ab3(dlong Nelements, dlong NhaloElements,
@@ -131,7 +162,7 @@ protected:
 
   kernel_t updateKernel;
 
-  virtual void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt);
+  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt);
 
 public:
   lserk4(dlong Nelements, dlong NhaloElements,
@@ -183,13 +214,13 @@ protected:
   dfloat facold;
   dfloat sqrtinvNtotal;
 
-  virtual void Backup(deviceMemory<dfloat> &o_Q);
-  virtual void Restore(deviceMemory<dfloat> &o_Q);
-  virtual void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq);
+  void Backup(deviceMemory<dfloat> &o_Q);
+  void Restore(deviceMemory<dfloat> &o_Q);
+  void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq);
 
-  virtual void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt);
+  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt);
 
-  virtual dfloat Estimater(deviceMemory<dfloat>& o_q);
+  dfloat Estimater(deviceMemory<dfloat>& o_q);
 
 public:
   dopri5(dlong Nelements, dlong NhaloElements,
@@ -217,9 +248,7 @@ protected:
 
   kernel_t updateKernel;
 
-  virtual void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
-
-  virtual void UpdateCoefficients();
+  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
 
 public:
   saab3(dlong _Nelements, dlong _NhaloElements,
@@ -275,15 +304,13 @@ protected:
   dfloat facold;
   dfloat sqrtinvNtotal;
 
-  virtual void Backup(deviceMemory<dfloat> &o_Q);
-  virtual void Restore(deviceMemory<dfloat> &o_Q);
-  virtual void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq);
+  void Backup(deviceMemory<dfloat> &o_Q);
+  void Restore(deviceMemory<dfloat> &o_Q);
+  void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq);
 
-  virtual void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt);
+  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt);
 
   dfloat Estimater(deviceMemory<dfloat>& o_q);
-
-  void UpdateCoefficients();
 
 public:
   sark4(dlong _Nelements, dlong _NhaloElements,
@@ -340,15 +367,13 @@ protected:
   dfloat facold;
   dfloat sqrtinvNtotal;
 
-  virtual void Backup(deviceMemory<dfloat> &o_Q);
-  virtual void Restore(deviceMemory<dfloat> &o_Q);
-  virtual void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq);
+  void Backup(deviceMemory<dfloat> &o_Q);
+  void Restore(deviceMemory<dfloat> &o_Q);
+  void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq);
 
-  virtual void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt);
+  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt);
 
   dfloat Estimater(deviceMemory<dfloat>& o_q);
-
-  void UpdateCoefficients();
 
 public:
   sark5(dlong _Nelements, dlong _NhaloElements,
@@ -376,7 +401,7 @@ protected:
 
   kernel_t rhsKernel;
 
-  virtual void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
+  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
 
 public:
   extbdf3(dlong Nelements, dlong NhaloElements,
@@ -403,7 +428,7 @@ protected:
 
   kernel_t rhsKernel;
 
-  virtual void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
+  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
 
 public:
   ssbdf3(dlong Nelements, dlong NhaloElements,
@@ -425,7 +450,7 @@ protected:
   int Nfields;
 
   deviceMemory<int> o_shiftIndex;
-  deviceMemory<int> h_shiftIndex;
+  pinnedMemory<int> h_shiftIndex;
 
   memory<dfloat> mrdt;
   deviceMemory<dfloat> o_mrdt;
@@ -438,7 +463,7 @@ protected:
   kernel_t updateKernel;
   kernel_t traceUpdateKernel;
 
-  virtual void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
+  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
 
 public:
   mrab3(dlong _Nelements, dlong _NhaloElements,
@@ -465,7 +490,7 @@ protected:
   memory<dfloat> mrdt;
   deviceMemory<dfloat> o_mrdt;
 
-  memory<dfloat> saab_x, saab_a, saab_b;
+  pinnedMemory<dfloat> h_saab_x, h_saab_a, h_saab_b;
   deviceMemory<dfloat> o_saab_x, o_saab_a, o_saab_b;
 
   deviceMemory<dfloat> o_rhsq0, o_rhsq, o_fQM;
@@ -473,9 +498,7 @@ protected:
   kernel_t updateKernel;
   kernel_t traceUpdateKernel;
 
-  virtual void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
-
-  void UpdateCoefficients();
+  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
 
 public:
   mrsaab3(dlong _Nelements, dlong _NhaloElements,
@@ -492,192 +515,459 @@ public:
 /* Derived Time Integrators which step PML fields */
 /**************************************************/
 
-/* Adams Bashforth, order 3 */
-class ab3_pml: public ab3 {
-private:
+//base pml time stepper class
+class pmlTimeStepperBase_t {
+public:
+  platform_t platform;
+  comm_t comm;
+
+  dlong N;
+  dlong Nhalo;
   dlong Npml;
 
-  deviceMemory<dfloat> o_pmlq;
+  dfloat dt;
+
+  pmlTimeStepperBase_t(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
+                    int Np, int Nfields, int Npmlfields,
+                    platform_t& _platform, comm_t _comm):
+    platform(_platform),
+    comm(_comm),
+    N(Nelements*Np*Nfields),
+    Nhalo(NhaloElements*Np*Nfields),
+    Npml(NpmlElements*Np*Npmlfields) {}
+
+  virtual void Run(solver_t& solver,
+                   deviceMemory<dfloat>& o_q,
+                   deviceMemory<dfloat>& o_pmlq,
+                   dfloat start, dfloat end) = 0;
+
+  void SetTimeStep(dfloat dt_) {dt = dt_;};
+
+  dfloat GetTimeStep() {return dt;};
+
+  virtual dfloat GetGamma() {
+    LIBP_FORCE_ABORT("GetGamma() not available in this Timestepper");
+    return 0.0;
+  }
+};
+
+/* Adams Bashforth, order 3 */
+class ab3_pml: public pmlTimeStepperBase_t {
+private:
+  static constexpr int Nstages{3};
+  int shiftIndex;
+
+  memory<dfloat> ab_a;
+  deviceMemory<dfloat> o_ab_a;
+
+  deviceMemory<dfloat> o_rhsq;
   deviceMemory<dfloat> o_rhspmlq;
 
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
+  kernel_t updateKernel;
+
+  void Step(solver_t& solver,
+            deviceMemory<dfloat>& o_q,
+            deviceMemory<dfloat>& o_pmlq,
+            dfloat time, dfloat dt, int order);
 
 public:
   ab3_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
           int Np, int Nfields, int Npmlfields,
           platform_t& _platform, comm_t _comm);
+
+  void Run(solver_t& solver,
+           deviceMemory<dfloat>& o_q,
+           deviceMemory<dfloat>& o_pmlq,
+           dfloat start, dfloat end);
 };
 
 /* Low-Storage Explicit Runge-Kutta, order 4 */
-class lserk4_pml: public lserk4 {
+class lserk4_pml: public pmlTimeStepperBase_t {
 private:
-  dlong Npml;
+  int Nrk;
+  memory<dfloat> rka, rkb, rkc;
 
-  deviceMemory<dfloat> o_pmlq;
+  deviceMemory<dfloat> o_rhsq;
+  deviceMemory<dfloat> o_resq;
   deviceMemory<dfloat> o_rhspmlq;
   deviceMemory<dfloat> o_respmlq;
 
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt);
+  deviceMemory<dfloat> o_saveq;
+  deviceMemory<dfloat> o_savepmlq;
+
+  kernel_t updateKernel;
+
+  void Step(solver_t& solver,
+            deviceMemory<dfloat>& o_q,
+            deviceMemory<dfloat>& o_pmlq,
+            dfloat time, dfloat dt);
 
 public:
   lserk4_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
             int Np, int Nfields, int Npmlfields,
             platform_t& _platform, comm_t _comm);
+
+  void Run(solver_t& solver,
+           deviceMemory<dfloat>& o_q,
+           deviceMemory<dfloat>& o_pmlq,
+           dfloat start, dfloat end);
 };
 
 /* Dormand-Prince method */
 /* Explict Runge-Kutta, order 5 with embedded order 4 and adaptive time-stepping */
-class dopri5_pml: public dopri5 {
+class dopri5_pml: public pmlTimeStepperBase_t {
 private:
-  dlong Npml;
+  int Nrk;
 
-  deviceMemory<dfloat> o_pmlq;
+  dlong Nblock;
+
+  memory<dfloat> rkC, rkA, rkE;
+  deviceMemory<dfloat> o_rkA, o_rkE;
+
+  deviceMemory<dfloat> o_errtmp;
+  pinnedMemory<dfloat> h_errtmp;
+
+  deviceMemory<dfloat> o_rhsq;
+  deviceMemory<dfloat> o_rkq;
+  deviceMemory<dfloat> o_rkrhsq;
   deviceMemory<dfloat> o_rhspmlq;
   deviceMemory<dfloat> o_rkpmlq;
   deviceMemory<dfloat> o_rkrhspmlq;
 
+  deviceMemory<dfloat> o_rkerr;
+
+  deviceMemory<dfloat> o_saveq;
   deviceMemory<dfloat> o_savepmlq;
 
+
+  kernel_t rkUpdateKernel;
   kernel_t rkPmlUpdateKernel;
+  kernel_t rkStageKernel;
+  kernel_t rkErrorEstimateKernel;
 
-  void Backup(deviceMemory<dfloat> &o_Q);
-  void Restore(deviceMemory<dfloat> &o_Q);
-  void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq);
+  dfloat dtMIN; //minumum allowed timestep
+  dfloat ATOL;  //absolute error tolerance
+  dfloat RTOL;  //relative error tolerance
+  dfloat safe;   //safety factor
 
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt);
+  //error control parameters
+  dfloat beta;
+  dfloat factor1;
+  dfloat factor2;
+
+  dfloat exp1;
+  dfloat invfactor1;
+  dfloat invfactor2;
+  dfloat facold;
+  dfloat sqrtinvNtotal;
+
+  void Backup(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq);
+  void Restore(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq);
+  void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq,
+                  deviceMemory<dfloat> &o_pmlq, deviceMemory<dfloat> &o_rpmlq);
+
+  void Step(solver_t& solver,
+            deviceMemory<dfloat>& o_q,
+            deviceMemory<dfloat>& o_pmlq,
+            dfloat time, dfloat dt);
+
+  dfloat Estimater(deviceMemory<dfloat>& o_q);
 
 public:
   dopri5_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
             int Np, int Nfields, int Npmlfields,
             platform_t& _platform, comm_t _comm);
+
+  void Run(solver_t& solver,
+           deviceMemory<dfloat>& o_q,
+           deviceMemory<dfloat>& o_pmlq,
+           dfloat start, dfloat end);
 };
 
 /* Semi-Analytic Adams-Bashforth, order 3 */
 // Note: PML fields are not stepped Semi-Analytically
-class saab3_pml: public saab3 {
+class saab3_pml: public pmlTimeStepperBase_t {
 private:
-  dlong Npml;
+  static constexpr int Nstages{3};
+  int shiftIndex;
+
+  int Np, Nfields;
+  dlong Nblock, Nelements, NhaloElements;
+
+  memory<dfloat> lambda;
+
+  pinnedMemory<dfloat> h_saab_x, h_saab_a;
+  deviceMemory<dfloat> o_saab_x, o_saab_a;
 
   memory<dfloat> pmlsaab_x, pmlsaab_a;
   deviceMemory<dfloat> o_pmlsaab_x, o_pmlsaab_a;
 
-  deviceMemory<dfloat> o_pmlq;
+  deviceMemory<dfloat> o_rhsq;
   deviceMemory<dfloat> o_rhspmlq;
 
+  kernel_t updateKernel;
   kernel_t pmlUpdateKernel;
 
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
+  void Step(solver_t& solver,
+            deviceMemory<dfloat>& o_q,
+            deviceMemory<dfloat>& o_pmlq,
+            dfloat time, dfloat dt, int order);
 
 public:
   saab3_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
             int Np, int Nfields, int _Npmlfields,
             memory<dfloat> _lambda,
             platform_t& _platform, comm_t _comm);
+
+  void Run(solver_t& solver,
+           deviceMemory<dfloat>& o_q,
+           deviceMemory<dfloat>& o_pmlq,
+           dfloat start, dfloat end);
 };
 
 /* Semi-Analytic Explict Runge-Kutta, order 4 with embedded order 3 and adaptive time-stepping */
 // Note: PML fields are not stepped Semi-Analytically
-class sark4_pml: public sark4 {
+class sark4_pml: public pmlTimeStepperBase_t {
 private:
-  dlong Npml;
+  static constexpr int Nrk{5};
+  int order, embeddedOrder;
 
+  int Np, Nfields;
+  dlong Nblock, Nelements, NhaloElements;
+
+  memory<dfloat> lambda;
+
+  memory<dfloat> rkC;
+  deviceMemory<dfloat> o_rkX, o_rkA, o_rkE;
+  pinnedMemory<dfloat> h_rkX, h_rkA, h_rkE;
   memory<dfloat> pmlrkA;
   deviceMemory<dfloat> o_pmlrkA;
 
-  deviceMemory<dfloat> o_pmlq;
+  deviceMemory<dfloat> o_rhsq;
+  deviceMemory<dfloat> o_rkq;
+  deviceMemory<dfloat> o_rkrhsq;
   deviceMemory<dfloat> o_rhspmlq;
   deviceMemory<dfloat> o_rkpmlq;
   deviceMemory<dfloat> o_rkrhspmlq;
 
+  deviceMemory<dfloat> o_rkerr;
+
+  deviceMemory<dfloat> o_saveq;
   deviceMemory<dfloat> o_savepmlq;
 
+  deviceMemory<dfloat> o_errtmp;
+  pinnedMemory<dfloat> h_errtmp;
+
+  kernel_t rkUpdateKernel;
   kernel_t rkPmlUpdateKernel;
+  kernel_t rkStageKernel;
   kernel_t rkPmlStageKernel;
+  kernel_t rkErrorEstimateKernel;
 
-  void Backup(deviceMemory<dfloat> &o_Q);
-  void Restore(deviceMemory<dfloat> &o_Q);
-  void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq);
+  dfloat dtMIN; //minumum allowed timestep
+  dfloat ATOL;  //absolute error tolerance
+  dfloat RTOL;  //relative error tolerance
+  dfloat safe;   //safety factor
 
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt);
+  //error control parameters
+  dfloat beta;
+  dfloat factor1;
+  dfloat factor2;
+
+  dfloat exp1;
+  dfloat invfactor1;
+  dfloat invfactor2;
+  dfloat facold;
+  dfloat sqrtinvNtotal;
+
+  void Backup(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq);
+  void Restore(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq);
+  void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq,
+                  deviceMemory<dfloat> &o_pmlq, deviceMemory<dfloat> &o_rpmlq);
+
+  void Step(solver_t& solver,
+            deviceMemory<dfloat>& o_q,
+            deviceMemory<dfloat>& o_pmlq,
+            dfloat time, dfloat dt);
+
+  dfloat Estimater(deviceMemory<dfloat>& o_q);
 
 public:
   sark4_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
             int Np, int Nfields, int _Npmlfields,
             memory<dfloat> _lambda, platform_t& _platform, comm_t _comm);
+
+  void Run(solver_t& solver,
+           deviceMemory<dfloat>& o_q,
+           deviceMemory<dfloat>& o_pmlq,
+           dfloat start, dfloat end);
 };
 
 /* Semi-Analytic Explict Runge-Kutta, order 5 with embedded order 4 and adaptive time-stepping */
 // Note: PML fields are not stepped Semi-Analytically
-class sark5_pml: public sark5 {
+class sark5_pml: public pmlTimeStepperBase_t {
 private:
-  dlong Npml;
+  static constexpr int Nrk{7};
+  int order, embeddedOrder;
 
+  int Np, Nfields;
+  dlong Nblock, Nelements, NhaloElements;
+
+  memory<dfloat> lambda;
+
+  memory<dfloat> rkC;
+  deviceMemory<dfloat> o_rkX, o_rkA, o_rkE;
+  pinnedMemory<dfloat> h_rkX, h_rkA, h_rkE;
   memory<dfloat> pmlrkA;
   deviceMemory<dfloat> o_pmlrkA;
 
-  deviceMemory<dfloat> o_pmlq;
+
+  deviceMemory<dfloat> o_rhsq;
+  deviceMemory<dfloat> o_rkq;
+  deviceMemory<dfloat> o_rkrhsq;
   deviceMemory<dfloat> o_rhspmlq;
   deviceMemory<dfloat> o_rkpmlq;
   deviceMemory<dfloat> o_rkrhspmlq;
 
+  deviceMemory<dfloat> o_rkerr;
+
+  deviceMemory<dfloat> o_saveq;
   deviceMemory<dfloat> o_savepmlq;
 
+  deviceMemory<dfloat> o_errtmp;
+  pinnedMemory<dfloat> h_errtmp;
+
+  kernel_t rkUpdateKernel;
   kernel_t rkPmlUpdateKernel;
+  kernel_t rkStageKernel;
   kernel_t rkPmlStageKernel;
+  kernel_t rkErrorEstimateKernel;
 
-  void Backup(deviceMemory<dfloat> &o_Q);
-  void Restore(deviceMemory<dfloat> &o_Q);
-  void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq);
+  dfloat dtMIN; //minumum allowed timestep
+  dfloat ATOL;  //absolute error tolerance
+  dfloat RTOL;  //relative error tolerance
+  dfloat safe;   //safety factor
 
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt);
+  //error control parameters
+  dfloat beta;
+  dfloat factor1;
+  dfloat factor2;
+
+  dfloat exp1;
+  dfloat invfactor1;
+  dfloat invfactor2;
+  dfloat facold;
+  dfloat sqrtinvNtotal;
+
+  void Backup(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq);
+  void Restore(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq);
+  void AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq,
+                  deviceMemory<dfloat> &o_pmlq, deviceMemory<dfloat> &o_rpmlq);
+
+  void Step(solver_t& solver,
+            deviceMemory<dfloat>& o_q,
+            deviceMemory<dfloat>& o_pmlq,
+            dfloat time, dfloat dt);
+
+  dfloat Estimater(deviceMemory<dfloat>& o_q);
 
 public:
   sark5_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
             int Np, int Nfields, int _Npmlfields,
             memory<dfloat> _lambda, platform_t& _platform, comm_t _comm);
+
+  void Run(solver_t& solver,
+           deviceMemory<dfloat>& o_q,
+           deviceMemory<dfloat>& o_pmlq,
+           dfloat start, dfloat end);
 };
 
-
 /* Multi-rate Adams-Bashforth, order 3 */
-class mrab3_pml: public mrab3 {
+class mrab3_pml: public pmlTimeStepperBase_t {
 private:
-  dlong Npml;
+  mesh_t mesh;
+
+  static constexpr int Nstages{3};
+  int Nlevels;
+  int Nfields;
   int Npmlfields;
 
-  deviceMemory<dfloat> o_pmlq;
+  deviceMemory<int> o_shiftIndex;
+  pinnedMemory<int> h_shiftIndex;
+
+  memory<dfloat> mrdt;
+  deviceMemory<dfloat> o_mrdt;
+
+  memory<dfloat> ab_a, ab_b;
+  deviceMemory<dfloat> o_ab_a, o_ab_b;
+
+  deviceMemory<dfloat> o_rhsq0, o_rhsq, o_fQM;
   deviceMemory<dfloat> o_rhspmlq0, o_rhspmlq;
 
+  kernel_t updateKernel;
   kernel_t pmlUpdateKernel;
+  kernel_t traceUpdateKernel;
 
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
+  void Step(solver_t& solver,
+            deviceMemory<dfloat>& o_q,
+            deviceMemory<dfloat>& o_pmlq,
+            dfloat time, dfloat dt, int order);
 
 public:
   mrab3_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
             int Np, int Nfields, int _Npmlfields, platform_t& _platform, mesh_t& _mesh);
+
+  void Run(solver_t& solver,
+           deviceMemory<dfloat>& o_q,
+           deviceMemory<dfloat>& o_pmlq,
+           dfloat start, dfloat end);
 };
 
 /* Multi-rate Semi-Analytic Adams-Bashforth, order 3 */
 // Note: PML fields are not stepped Semi-Analytically
-class mrsaab3_pml: public mrsaab3 {
+class mrsaab3_pml: public pmlTimeStepperBase_t {
 private:
-  dlong Npml;
+  mesh_t mesh;
+
+  static constexpr int Nstages{3};
+  int Nlevels;
+  int Nfields;
   int Npmlfields;
 
-  deviceMemory<dfloat> o_pmlq;
+  memory<dfloat> lambda;
 
+  deviceMemory<int> o_shiftIndex;
+  pinnedMemory<int> h_shiftIndex;
+
+  memory<dfloat> mrdt;
+  deviceMemory<dfloat> o_mrdt;
+
+  pinnedMemory<dfloat> h_saab_x, h_saab_a, h_saab_b;
+  deviceMemory<dfloat> o_saab_x, o_saab_a, o_saab_b;
   memory<dfloat> pmlsaab_a, pmlsaab_b;
   deviceMemory<dfloat> o_pmlsaab_a, o_pmlsaab_b;
 
+  deviceMemory<dfloat> o_rhsq0, o_rhsq, o_fQM;
   deviceMemory<dfloat> o_rhspmlq0, o_rhspmlq;
 
+  kernel_t updateKernel;
   kernel_t pmlUpdateKernel;
+  kernel_t traceUpdateKernel;
 
-  void Step(solver_t& solver, deviceMemory<dfloat>& o_q, dfloat time, dfloat dt, int order);
+  void Step(solver_t& solver,
+            deviceMemory<dfloat>& o_q,
+            deviceMemory<dfloat>& o_pmlq,
+            dfloat time, dfloat dt, int order);
 
 public:
   mrsaab3_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
             int Np, int Nfields, int _Npmlfields,
             memory<dfloat> _lambda, platform_t& _platform, mesh_t& _mesh);
+
+  void Run(solver_t& solver,
+           deviceMemory<dfloat>& o_q,
+           deviceMemory<dfloat>& o_pmlq,
+           dfloat start, dfloat end);
 };
 
 } //namespace TimeStepper

--- a/libs/timeStepper/okl/timeStepperAB.okl
+++ b/libs/timeStepper/okl/timeStepperAB.okl
@@ -41,8 +41,9 @@ SOFTWARE.
 
     //compute update
     dfloat dq = 0.0;
-    for (int i=0;i<p_Nstages;i++)
-      dq += a[i]*rhsqi[i][n];
+    for (int i=0;i<p_Nstages;i++) {
+      if (a[i]!= 0.0) dq += a[i]*rhsqi[i][n];
+    }
 
     q[n] += dt*dq;
   }

--- a/libs/timeStepper/okl/timeStepperDOPRI5.okl
+++ b/libs/timeStepper/okl/timeStepperDOPRI5.okl
@@ -38,7 +38,7 @@ SOFTWARE.
     dfloat r_q = q[n];
 
     for (int i=0;i<rk;i++)
-      r_q += dt*rkA[7*rk + i]*rkrhsq[n+i*N];
+      if (rkA[7*rk + i] != 0.0) r_q += dt*rkA[7*rk + i]*rkrhsq[n+i*N];
 
     rkq[n] = r_q;
   }
@@ -64,8 +64,8 @@ SOFTWARE.
       dfloat r_q = q[n];
       dfloat r_rkerr = 0.;
       for (int i=0;i<6;i++) {
-        r_q     += dt*rkA[7*rk + i]*rkrhsq[n+i*N];
-        r_rkerr += dt*rkE[       i]*rkrhsq[n+i*N];
+        if (rkA[7*rk + i] != 0.0) r_q     += dt*rkA[7*rk + i]*rkrhsq[n+i*N];
+        if (rkE[       i] != 0.0) r_rkerr += dt*rkE[       i]*rkrhsq[n+i*N];
       }
       r_q     += dt*rkA[7*rk + 6]*r_rhsq;
       r_rkerr += dt*rkE[       6]*r_rhsq;
@@ -95,9 +95,9 @@ SOFTWARE.
     if (rk==6) { //last stage
       dfloat r_q = q[n];
       for (int i=0;i<6;i++) {
-        r_q     += dt*rkA[7*rk + i]*rkrhsq[n+i*N];
+        if (rkA[7*rk + i] != 0.0) r_q += dt*rkA[7*rk + i]*rkrhsq[n+i*N];
       }
-      r_q     += dt*rkA[7*rk + 6]*r_rhsq;
+      r_q += dt*rkA[7*rk + 6]*r_rhsq;
 
       rkq[n] = r_q;
     }

--- a/libs/timeStepper/okl/timeStepperEXTBDF.okl
+++ b/libs/timeStepper/okl/timeStepperEXTBDF.okl
@@ -48,8 +48,10 @@ SOFTWARE.
     //compute rhs
     dfloat qn = q[n];
     dfloat rhsn = b[1]*qn + dt*a[0]*Fi[0][n]; //First q value comes from q, not history
-    for (int i=1;i<p_Nstages;i++)
-      rhsn += b[i+1]*qni[i][n] + dt*a[i]*Fi[i][n];
+    for (int i=1;i<p_Nstages;i++) {
+      if (b[i+1] != 0.0) rhsn += b[i+1]*qni[i][n];
+      if (a[i]   != 0.0) rhsn += dt*a[i]*Fi[i][n];
+    }
 
     rhs[n] = rhsn/dt; //write RHS
     qni[0][n] = qn; //write q into history

--- a/libs/timeStepper/okl/timeStepperLSERK4.okl
+++ b/libs/timeStepper/okl/timeStepperLSERK4.okl
@@ -34,14 +34,11 @@ SOFTWARE.
 
   // Low storage Runge Kutta time step update
   for(dlong n=0;n<N;++n;@tile(256,@outer,@inner)){
-    dfloat r_resq = resq[n];
-    dfloat r_rhsq = rhsq[n];
-    dfloat r_q    = q[n];
 
-    r_resq = rka*r_resq + dt*r_rhsq;
-    r_q   += rkb*r_resq;
+    dfloat r_resq = dt*rhsq[n];
+    if (rka != 0.0) r_resq += rka*resq[n];
 
     resq[n] = r_resq;
-    q[n]    = r_q;
+    q[n]    = q[n] + rkb*r_resq;
   }
 }

--- a/libs/timeStepper/okl/timeStepperMRAB.okl
+++ b/libs/timeStepper/okl/timeStepperMRAB.okl
@@ -62,7 +62,7 @@ SOFTWARE.
           dfloat qn = q[id+f*p_Np];
 
           for (int i=0;i<p_Nstages;i++)
-            qn += dt[lev]*a[i]*rhsqi[i][id+f*p_Np];
+            if (a[i] != 0.0) qn += dt[lev]*a[i]*rhsqi[i][id+f*p_Np];
 
           s_q[n+f*p_Np] = qn;
 
@@ -139,7 +139,7 @@ SOFTWARE.
           dfloat qn = q[id+f*p_Np];
 
           for (int i=0;i<p_Nstages;i++)
-            qn += dt[lev]*b[i]*rhsqi[i][id+f*p_Np];
+            if (b[i] != 0.0) qn += dt[lev]*b[i]*rhsqi[i][id+f*p_Np];
 
           s_q[n+f*p_Np] = qn;
         }
@@ -198,7 +198,7 @@ SOFTWARE.
         dfloat qn = q[id+f*p_Np];
 
         for (int i=0;i<p_Nstages;i++)
-          qn += dt[lev]*a[i]*rhsqi[i][id+f*p_Np];
+          if (a[i] != 0.0) qn += dt[lev]*a[i]*rhsqi[i][id+f*p_Np];
 
         q[id+f*p_Np] = qn;
 

--- a/libs/timeStepper/okl/timeStepperMRSAAB.okl
+++ b/libs/timeStepper/okl/timeStepperMRSAAB.okl
@@ -62,10 +62,10 @@ SOFTWARE.
         for(int f=0; f<p_Nfields; ++f) {
           dfloat qn = x[f+lev*p_Nfields]*q[id+f*p_Np];
 
-          for (int i=0;i<p_Nstages;i++)
-            qn += dt[lev]*a[i+f*p_Nstages*p_Nstages+lev*p_Nfields*p_Nstages*p_Nstages]
-                         *rhsqi[i][id+f*p_Np];
-
+          for (int i=0;i<p_Nstages;i++) {
+            const dfloat ai = a[i+f*p_Nstages*p_Nstages+lev*p_Nfields*p_Nstages*p_Nstages];
+            if (ai != 0.0) qn += dt[lev]*ai*rhsqi[i][id+f*p_Np];
+          }
           s_q[n+f*p_Np] = qn;
 
           if (p_Nstages>1)
@@ -141,9 +141,10 @@ SOFTWARE.
         for(int f=0; f<p_Nfields; ++f) {
           dfloat qn = x[f+lev*p_Nfields]*q[id+f*p_Np];
 
-          for (int i=0;i<p_Nstages;i++)
-            qn += dt[lev]*b[i+f*p_Nstages*p_Nstages+lev*p_Nfields*p_Nstages*p_Nstages]
-                         *rhsqi[i][id+f*p_Np];
+          for (int i=0;i<p_Nstages;i++) {
+            const dfloat bi = b[i+f*p_Nstages*p_Nstages+lev*p_Nfields*p_Nstages*p_Nstages];
+            if (bi != 0.0) qn += dt[lev]*bi*rhsqi[i][id+f*p_Np];
+          }
 
           s_q[n+f*p_Np] = qn;
         }
@@ -202,7 +203,7 @@ SOFTWARE.
         dfloat qn = q[id+f*p_Np];
 
         for (int i=0;i<p_Nstages;i++)
-          qn += dt[lev]*a[i]*rhsqi[i][id+f*p_Np];
+          if (a[i] != 0.0) qn += dt[lev]*a[i]*rhsqi[i][id+f*p_Np];
 
         q[id+f*p_Np] = qn;
 

--- a/libs/timeStepper/okl/timeStepperSAAB.okl
+++ b/libs/timeStepper/okl/timeStepperSAAB.okl
@@ -47,8 +47,10 @@ SOFTWARE.
       for (int f=0;f<p_Nfields;f++) {
         //compute update
         dfloat qn = x[f]*q[id + f*p_Np];
-        for (int i=0;i<p_Nstages;i++)
-          qn += dt*a[i+f*p_Nstages*p_Nstages]*rhsqi[i][id + f*p_Np];
+        for (int i=0;i<p_Nstages;i++) {
+          const dfloat ai = a[i+f*p_Nstages*p_Nstages];
+          if (ai != 0.0) qn += dt*ai*rhsqi[i][id + f*p_Np];
+        }
 
         q[id + f*p_Np] = qn;
       }
@@ -74,7 +76,7 @@ SOFTWARE.
     //compute update
     dfloat dq = 0.0;
     for (int i=0;i<p_Nstages;i++)
-      dq += a[i]*rhsqi[i][n];
+      if (a[i] != 0.0) dq += a[i]*rhsqi[i][n];
 
     q[n] += dt*dq;
   }

--- a/libs/timeStepper/okl/timeStepperSARK.okl
+++ b/libs/timeStepper/okl/timeStepperSARK.okl
@@ -43,8 +43,10 @@ SOFTWARE.
       for (int f=0;f<p_Nfields;f++) {
         dfloat r_q = rkX[rk+f*p_Nrk]*q[id+f*p_Np];
 
-        for (int i=0;i<rk;i++)
-          r_q += dt*rkA[p_Nrk*rk + i + f*p_Nrk*p_Nrk]*rkrhsq[id+f*p_Np+i*Nelements*p_Np*p_Nfields];
+        for (int i=0;i<rk;i++) {
+          const dfloat ai = rkA[p_Nrk*rk + i + f*p_Nrk*p_Nrk];
+          if (ai != 0.0) r_q += dt*ai*rkrhsq[id+f*p_Np+i*Nelements*p_Np*p_Nfields];
+        }
 
         rkq[id+f*p_Np] = r_q;
       }
@@ -78,8 +80,10 @@ SOFTWARE.
           dfloat r_q = rkX[rk+f*p_Nrk]*q[id+f*p_Np];
           dfloat r_rkerr = 0.;
           for (int i=0;i<p_Nrk-1;i++) {
-            r_q     += dt*rkA[p_Nrk*rk + i + f*p_Nrk*p_Nrk]*rkrhsq[id+f*p_Np+i*Nelements*p_Np*p_Nfields];
-            r_rkerr += dt*rkE[           i + f*p_Nrk      ]*rkrhsq[id+f*p_Np+i*Nelements*p_Np*p_Nfields];
+            const dfloat ai = rkA[p_Nrk*rk + i + f*p_Nrk*p_Nrk];
+            const dfloat ei = rkE[           i + f*p_Nrk      ];
+            if (ai != 0.0) r_q     += dt*ai*rkrhsq[id+f*p_Np+i*Nelements*p_Np*p_Nfields];
+            if (ei != 0.0) r_rkerr += dt*ei*rkrhsq[id+f*p_Np+i*Nelements*p_Np*p_Nfields];
           }
           r_q     += dt*rkA[p_Nrk*rk + p_Nrk-1 + f*p_Nrk*p_Nrk]*r_rhsq;
           r_rkerr += dt*rkE[           p_Nrk-1 + f*p_Nrk      ]*r_rhsq;
@@ -151,8 +155,10 @@ SOFTWARE.
 
     dfloat r_q = q[n];
 
-    for (int i=0;i<rk;i++)
-      r_q += dt*rkA[p_Nrk*rk + i]*rkrhsq[n+i*N];
+    for (int i=0;i<rk;i++) {
+      const dfloat ai = rkA[p_Nrk*rk + i];
+      if (ai != 0.0) r_q += dt*ai*rkrhsq[n+i*N];
+    }
 
     rkq[n] = r_q;
   }
@@ -175,9 +181,10 @@ SOFTWARE.
     if (rk==p_Nrk-1) { //last stage
       dfloat r_q = q[n];
       for (int i=0;i<p_Nrk-1;i++) {
-        r_q     += dt*rkA[p_Nrk*rk + i]*rkrhsq[n+i*N];
+        const dfloat ai = rkA[p_Nrk*rk + i];
+        r_q += dt*rkA[p_Nrk*rk + i]*rkrhsq[n+i*N];
       }
-      r_q     += dt*rkA[p_Nrk*rk + p_Nrk-1]*r_rhsq;
+      r_q += dt*rkA[p_Nrk*rk + p_Nrk-1]*r_rhsq;
 
       rkq[n] = r_q;
     }

--- a/libs/timeStepper/timeStepper.cpp
+++ b/libs/timeStepper/timeStepper.cpp
@@ -33,7 +33,15 @@ void timeStepper_t::Run(solver_t& solver,
                         deviceMemory<dfloat>& o_q,
                         dfloat start, dfloat end) {
   assertInitialized();
-  ts->Run(solver, o_q, start, end);
+  ts->Run(solver, o_q, std::nullopt, start, end);
+}
+
+void timeStepper_t::RunWithPml(solver_t& solver,
+                               deviceMemory<dfloat>& o_q,
+                               deviceMemory<dfloat>& o_pmlq,
+                               dfloat start, dfloat end) {
+  assertInitialized();
+  ts->Run(solver, o_q, o_pmlq, start, end);
 }
 
 void timeStepper_t::SetTimeStep(dfloat dt_) {
@@ -53,34 +61,6 @@ dfloat timeStepper_t::GetGamma() {
 
 void timeStepper_t::assertInitialized() {
   LIBP_ABORT("timeStepper_t not initialized",
-             ts==nullptr);
-}
-
-void pmlTimeStepper_t::Run(solver_t& solver,
-                           deviceMemory<dfloat>& o_q,
-                           deviceMemory<dfloat>& o_pmlq,
-                           dfloat start, dfloat end) {
-  assertInitialized();
-  ts->Run(solver, o_q, o_pmlq, start, end);
-}
-
-void pmlTimeStepper_t::SetTimeStep(dfloat dt_) {
-  assertInitialized();
-  ts->SetTimeStep(dt_);
-}
-
-dfloat pmlTimeStepper_t::GetTimeStep() {
-  assertInitialized();
-  return ts->dt;
-}
-
-dfloat pmlTimeStepper_t::GetGamma() {
-  assertInitialized();
-  return ts->GetGamma();
-}
-
-void pmlTimeStepper_t::assertInitialized() {
-  LIBP_ABORT("pmlTimeStepper_t not initialized",
              ts==nullptr);
 }
 

--- a/libs/timeStepper/timeStepper.cpp
+++ b/libs/timeStepper/timeStepper.cpp
@@ -56,4 +56,32 @@ void timeStepper_t::assertInitialized() {
              ts==nullptr);
 }
 
+void pmlTimeStepper_t::Run(solver_t& solver,
+                           deviceMemory<dfloat>& o_q,
+                           deviceMemory<dfloat>& o_pmlq,
+                           dfloat start, dfloat end) {
+  assertInitialized();
+  ts->Run(solver, o_q, o_pmlq, start, end);
+}
+
+void pmlTimeStepper_t::SetTimeStep(dfloat dt_) {
+  assertInitialized();
+  ts->SetTimeStep(dt_);
+}
+
+dfloat pmlTimeStepper_t::GetTimeStep() {
+  assertInitialized();
+  return ts->dt;
+}
+
+dfloat pmlTimeStepper_t::GetGamma() {
+  assertInitialized();
+  return ts->GetGamma();
+}
+
+void pmlTimeStepper_t::assertInitialized() {
+  LIBP_ABORT("pmlTimeStepper_t not initialized",
+             ts==nullptr);
+}
+
 } //namespace libp

--- a/libs/timeStepper/timeStepperAB3.cpp
+++ b/libs/timeStepper/timeStepperAB3.cpp
@@ -41,8 +41,7 @@ ab3::ab3(dlong Nelements, dlong NhaloElements,
   //Nstages = 3;
   shiftIndex = 0;
 
-  memory<dfloat> rhsq(Nstages*N,0.0);
-  o_rhsq = platform.malloc<dfloat>(rhsq);
+  o_rhsq = platform.malloc<dfloat>(Nstages*N);
 
   properties_t kernelInfo = platform.props(); //copy base occa properties from solver
 
@@ -133,11 +132,8 @@ ab3_pml::ab3_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
   //Nstages = 3;
   shiftIndex = 0;
 
-  memory<dfloat> rhsq(Nstages*N,0.0);
-  o_rhsq = platform.malloc<dfloat>(rhsq);
-
-  memory<dfloat> rhspmlq(Nstages*Npml,0.0);
-  o_rhspmlq = platform.malloc<dfloat>(rhspmlq);
+  o_rhsq = platform.malloc<dfloat>(Nstages*N);
+  o_rhspmlq = platform.malloc<dfloat>(Nstages*Npml);
 
   properties_t kernelInfo = platform.props(); //copy base occa properties from solver
 

--- a/libs/timeStepper/timeStepperDOPRI5.cpp
+++ b/libs/timeStepper/timeStepperDOPRI5.cpp
@@ -300,54 +300,229 @@ dfloat dopri5::Estimater(deviceMemory<dfloat>& o_q){
 /**************************************************/
 
 dopri5_pml::dopri5_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
-                      int Np, int Nfields, int Npmlfields,
-                      platform_t& _platform, comm_t _comm):
-  dopri5(Nelements, NhaloElements, Np, Nfields, _platform, _comm),
-  Npml(Npmlfields*Np*NpmlElements) {
+                       int Np, int Nfields, int Npmlfields,
+                       platform_t& _platform, comm_t _comm):
+  pmlTimeStepperBase_t(Nelements, NpmlElements, NhaloElements,
+                       Np, Nfields, Npmlfields,
+                       _platform, _comm) {
 
-  if (Npml) {
-    memory<dfloat> pmlq(Npml,0.0);
-    o_pmlq = platform.malloc<dfloat>(pmlq);
+  Nrk = 7;
 
-    o_rhspmlq   = platform.malloc<dfloat>(Npml);
-    o_rkpmlq    = platform.malloc<dfloat>(Npml);
-    o_rkrhspmlq = platform.malloc<dfloat>(Nrk*Npml);
+  o_rhsq   = platform.malloc<dfloat>(N);
+  o_rkq    = platform.malloc<dfloat>(N+Nhalo);
+  o_rkrhsq = platform.malloc<dfloat>(Nrk*N);
+  o_rhspmlq   = platform.malloc<dfloat>(Npml);
+  o_rkpmlq    = platform.malloc<dfloat>(Npml);
+  o_rkrhspmlq = platform.malloc<dfloat>(Nrk*Npml);
 
-    o_savepmlq  = platform.malloc<dfloat>(Npml);
+  o_saveq  = platform.malloc<dfloat>(N);
+  o_savepmlq  = platform.malloc<dfloat>(Npml);
 
-    properties_t kernelInfo = platform.props(); //copy base occa properties from solver
+  o_rkerr  = platform.malloc<dfloat>(N);
 
-    const int blocksize = 256;
+  const int blocksize = 256;
 
-    //add defines
-    kernelInfo["defines/" "p_blockSize"] = (int)blocksize;
+  Nblock = (N+blocksize-1)/blocksize;
+  h_errtmp = platform.hostMalloc<dfloat>(Nblock);
+  o_errtmp = platform.malloc<dfloat>(Nblock);
 
-    rkPmlUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+  hlong Ntotal = N;
+  comm.Allreduce(Ntotal);
+
+  properties_t kernelInfo = platform.props(); //copy base occa properties from solver
+
+  //add defines
+  kernelInfo["defines/" "p_blockSize"] = (int)blocksize;
+
+  rkUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+                                    "timeStepperDOPRI5.okl",
+                                    "dopri5RkUpdate",
+                                    kernelInfo);
+
+  rkPmlUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
                                       "timeStepperDOPRI5.okl",
                                       "dopri5RkPmlUpdate",
                                       kernelInfo);
+
+  rkStageKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+                                    "timeStepperDOPRI5.okl",
+                                    "dopri5RkStage",
+                                    kernelInfo);
+
+  rkErrorEstimateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+                                    "timeStepperDOPRI5.okl",
+                                    "dopri5ErrorEstimate",
+                                    kernelInfo);
+
+  // Dormand Prince -order (4) 5 with PID timestep control
+  dfloat _rkC[7] = {0.0, 0.2, 0.3, 0.8, 8.0/9.0, 1.0, 1.0};
+  dfloat _rkA[7*7] ={             0.0,             0.0,            0.0,          0.0,             0.0,       0.0, 0.0,
+                                 0.2,             0.0,            0.0,          0.0,             0.0,       0.0, 0.0,
+                            3.0/40.0,        9.0/40.0,            0.0,          0.0,             0.0,       0.0, 0.0,
+                           44.0/45.0,      -56.0/15.0,       32.0/9.0,          0.0,             0.0,       0.0, 0.0,
+                      19372.0/6561.0, -25360.0/2187.0, 64448.0/6561.0, -212.0/729.0,             0.0,       0.0, 0.0,
+                       9017.0/3168.0,     -355.0/33.0, 46732.0/5247.0,   49.0/176.0, -5103.0/18656.0,       0.0, 0.0,
+                          35.0/384.0,             0.0,   500.0/1113.0,  125.0/192.0,  -2187.0/6784.0, 11.0/84.0, 0.0 };
+  dfloat _rkE[7] = {71.0/57600.0,  0.0, -71.0/16695.0, 71.0/1920.0, -17253.0/339200.0, 22.0/525.0, -1.0/40.0 };
+
+  rkC.malloc(Nrk);
+  rkE.malloc(Nrk);
+  rkA.malloc(Nrk*Nrk);
+
+  rkC.copyFrom(_rkC);
+  rkE.copyFrom(_rkE);
+  rkA.copyFrom(_rkA);
+
+  o_rkA = platform.malloc<dfloat>(rkA);
+  o_rkE = platform.malloc<dfloat>(rkE);
+
+  dtMIN = 1E-9; //minumum allowed timestep
+  ATOL = 1E-6;  //absolute error tolerance
+  RTOL = 1E-6;  //relative error tolerance
+  safe = 0.8;   //safety factor
+
+  //error control parameters
+  beta = 0.05;
+  factor1 = 0.2;
+  factor2 = 10.0;
+
+  exp1 = 0.2 - 0.75*beta;
+  invfactor1 = 1.0/factor1;
+  invfactor2 = 1.0/factor2;
+  facold = 1E-4;
+  sqrtinvNtotal = 1.0/sqrt(Ntotal);
+}
+
+void dopri5_pml::Run(solver_t& solver,
+                     deviceMemory<dfloat> &o_q,
+                     deviceMemory<dfloat> &o_pmlq,
+                     dfloat start, dfloat end) {
+
+  dfloat time = start;
+
+  // int rank;
+  // comm_rank_t(comm, &rank);
+
+  solver.Report(time,0);
+
+  dfloat outputInterval=0.0;
+  solver.settings.getSetting("OUTPUT INTERVAL", outputInterval);
+
+  dfloat outputTime = time + outputInterval;
+
+  int tstep=0, allStep=0;
+
+  while (time < end) {
+
+    LIBP_ABORT("Time step became too small at time step = " << tstep,
+               dt<dtMIN);
+    LIBP_ABORT("Solution became unstable at time step = " << tstep,
+               std::isnan(dt));
+
+    //check for final timestep
+    if (time+dt > end){
+      dt = end-time;
+    }
+
+    Step(solver, o_q, o_pmlq, time, dt);
+
+    // compute Dopri estimator
+    dfloat err = Estimater(o_q);
+
+    // build controller
+    dfloat fac1 = pow(err,exp1);
+    dfloat fac = fac1/pow(facold,beta);
+
+    fac = std::max(invfactor2, std::min(invfactor1,fac/safe));
+    dfloat dtnew = dt/fac;
+
+    if (err<1.0) { //dt is accepted
+
+      // check for output during this step and do a mini-step
+      if (time<outputTime && time+dt>=outputTime) {
+        dfloat savedt = dt;
+
+        // save rkq
+        Backup(o_rkq, o_rkpmlq);
+
+        // change dt to match output
+        dt = outputTime-time;
+
+        // if(!rank)
+        //   printf("Taking output mini step: %g\n", dt);
+
+        // time step to output
+        Step(solver, o_q, o_pmlq, time, dt);
+
+        // shift for output
+        o_rkq.copyTo(o_q);
+
+        // output  (print from rkq)
+        // if (!rank) printf("\n");
+        solver.Report(outputTime,tstep);
+
+        // restore time step
+        dt = savedt;
+
+        // increment next output time
+        outputTime += outputInterval;
+
+        // accept saved rkq
+        Restore(o_rkq, o_rkpmlq);
+        AcceptStep(o_q, o_rkq, o_pmlq, o_rkpmlq);
+      } else {
+        // accept rkq
+        AcceptStep(o_q, o_rkq, o_pmlq, o_rkpmlq);
+      }
+
+      time += dt;
+      while (time>outputTime) outputTime+= outputInterval; //catch up next output in case dt>outputInterval
+
+      constexpr dfloat errMax = 1.0e-4;  // hard coded factor ?
+      facold = std::max(err,errMax);
+
+      // if (!rank)
+      //   printf("\r time = %g (%d), dt = %g accepted                      ", time, allStep,  dt);
+
+      tstep++;
+    } else {
+      dtnew = dt/(std::max(invfactor1,fac1/safe));
+
+      // if (!rank)
+      //   printf("\r time = %g (%d), dt = %g rejected, trying %g", time, allStep, dt, dtnew);
+      // if (!rank)
+      //   printf("Repeating timestep %d. dt was %g, trying %g.\n", tstep, dt, dtnew);
+    }
+    dt = dtnew;
+    allStep++;
   }
+
+  // if (!rank)
+  //   printf("%d accepted steps and %d total steps\n", tstep, allStep);
 }
 
-void dopri5_pml::Backup(deviceMemory<dfloat> &o_Q) {
-  o_saveq.copyFrom(o_Q, N);
-  if (Npml)
-    o_savepmlq.copyFrom(o_rkpmlq, Npml);
+void dopri5_pml::Backup(deviceMemory<dfloat> &o_q,
+                        deviceMemory<dfloat> &o_pmlq) {
+  o_saveq.copyFrom(o_q, N);
+  o_savepmlq.copyFrom(o_pmlq, Npml);
 }
 
-void dopri5_pml::Restore(deviceMemory<dfloat> &o_Q) {
-  o_saveq.copyTo(o_Q, N);
-  if (Npml)
-    o_savepmlq.copyTo(o_rkpmlq, Npml);
+void dopri5_pml::Restore(deviceMemory<dfloat> &o_q,
+                         deviceMemory<dfloat> &o_pmlq) {
+  o_saveq.copyTo(o_q, N);
+  o_savepmlq.copyTo(o_pmlq, Npml);
 }
 
-void dopri5_pml::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq) {
+void dopri5_pml::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq,
+                            deviceMemory<dfloat> &o_pmlq, deviceMemory<dfloat> &o_rpmlq) {
   o_q.copyFrom(o_rq, N);
-  if (Npml)
-    o_pmlq.copyFrom(o_rkpmlq, Npml);
+  o_pmlq.copyFrom(o_rpmlq, Npml);
 }
 
-void dopri5_pml::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloat _dt) {
+void dopri5_pml::Step(solver_t& solver,
+                      deviceMemory<dfloat> &o_q,
+                      deviceMemory<dfloat> &o_pmlq,
+                      dfloat time, dfloat _dt) {
 
   //RK step
   for(int rk=0;rk<Nrk;++rk){
@@ -364,14 +539,13 @@ void dopri5_pml::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, 
                   o_q,
                   o_rkrhsq,
                   o_rkq);
-    if (Npml)
-      rkStageKernel(Npml,
-                    rk,
-                    _dt,
-                    o_rkA,
-                    o_pmlq,
-                    o_rkrhspmlq,
-                    o_rkpmlq);
+    rkStageKernel(Npml,
+                  rk,
+                  _dt,
+                  o_rkA,
+                  o_pmlq,
+                  o_rkrhspmlq,
+                  o_rkpmlq);
 
     //evaluate ODE rhs = f(q,t)
     solver.rhsf_pml(o_rkq, o_rkpmlq, o_rhsq, o_rhspmlq, currentTime);
@@ -391,8 +565,7 @@ void dopri5_pml::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, 
                    o_rkrhsq,
                    o_rkq,
                    o_rkerr);
-    if (Npml)
-      rkPmlUpdateKernel(Npml,
+    rkPmlUpdateKernel(Npml,
                      rk,
                      _dt,
                      o_rkA,
@@ -401,6 +574,31 @@ void dopri5_pml::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, 
                      o_rkrhspmlq,
                      o_rkpmlq);
   }
+}
+
+dfloat dopri5_pml::Estimater(deviceMemory<dfloat>& o_q){
+
+  //Error estimation
+  //E. HAIRER, S.P. NORSETT AND G. WANNER, SOLVING ORDINARY
+  //      DIFFERENTIAL EQUATIONS I. NONSTIFF PROBLEMS. 2ND EDITION.
+  rkErrorEstimateKernel(N,
+                        ATOL,
+                        RTOL,
+                        o_q,
+                        o_rkq,
+                        o_rkerr,
+                        o_errtmp);
+
+  h_errtmp.copyFrom(o_errtmp);
+  dfloat err = 0;
+  for(dlong n=0;n<Nblock;++n){
+    err += h_errtmp[n];
+  }
+  comm.Allreduce(err);
+
+  err = sqrt(err)*sqrtinvNtotal;
+
+  return err;
 }
 
 } //namespace TimeStepper

--- a/libs/timeStepper/timeStepperDOPRI5.cpp
+++ b/libs/timeStepper/timeStepperDOPRI5.cpp
@@ -34,260 +34,16 @@ namespace TimeStepper {
 dopri5::dopri5(dlong Nelements, dlong NhaloElements,
                int Np, int Nfields,
                platform_t& _platform, comm_t _comm):
-  timeStepperBase_t(Nelements, NhaloElements,
-                    Np, Nfields, _platform, _comm) {
+  dopri5(Nelements, 0, NhaloElements,
+         Np, Nfields, 0,
+         _platform, _comm) {}
 
-  Nrk = 7;
-
-  o_rhsq   = platform.malloc<dfloat>(N);
-  o_rkq    = platform.malloc<dfloat>(N+Nhalo);
-  o_rkrhsq = platform.malloc<dfloat>(Nrk*N);
-  o_rkerr  = platform.malloc<dfloat>(N);
-
-  o_saveq  = platform.malloc<dfloat>(N);
-
-  const int blocksize = 256;
-
-  Nblock = (N+blocksize-1)/blocksize;
-  h_errtmp = platform.hostMalloc<dfloat>(Nblock);
-  o_errtmp = platform.malloc<dfloat>(Nblock);
-
-  hlong Ntotal = N;
-  comm.Allreduce(Ntotal);
-
-  properties_t kernelInfo = platform.props(); //copy base occa properties from solver
-
-  //add defines
-  kernelInfo["defines/" "p_blockSize"] = (int)blocksize;
-
-  rkUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
-                                    "timeStepperDOPRI5.okl",
-                                    "dopri5RkUpdate",
-                                    kernelInfo);
-
-  rkStageKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
-                                    "timeStepperDOPRI5.okl",
-                                    "dopri5RkStage",
-                                    kernelInfo);
-
-  rkErrorEstimateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
-                                    "timeStepperDOPRI5.okl",
-                                    "dopri5ErrorEstimate",
-                                    kernelInfo);
-
-  // Dormand Prince -order (4) 5 with PID timestep control
-  dfloat _rkC[7] = {0.0, 0.2, 0.3, 0.8, 8.0/9.0, 1.0, 1.0};
-  dfloat _rkA[7*7] ={             0.0,             0.0,            0.0,          0.0,             0.0,       0.0, 0.0,
-                                 0.2,             0.0,            0.0,          0.0,             0.0,       0.0, 0.0,
-                            3.0/40.0,        9.0/40.0,            0.0,          0.0,             0.0,       0.0, 0.0,
-                           44.0/45.0,      -56.0/15.0,       32.0/9.0,          0.0,             0.0,       0.0, 0.0,
-                      19372.0/6561.0, -25360.0/2187.0, 64448.0/6561.0, -212.0/729.0,             0.0,       0.0, 0.0,
-                       9017.0/3168.0,     -355.0/33.0, 46732.0/5247.0,   49.0/176.0, -5103.0/18656.0,       0.0, 0.0,
-                          35.0/384.0,             0.0,   500.0/1113.0,  125.0/192.0,  -2187.0/6784.0, 11.0/84.0, 0.0 };
-  dfloat _rkE[7] = {71.0/57600.0,  0.0, -71.0/16695.0, 71.0/1920.0, -17253.0/339200.0, 22.0/525.0, -1.0/40.0 };
-
-  rkC.malloc(Nrk);
-  rkE.malloc(Nrk);
-  rkA.malloc(Nrk*Nrk);
-
-  rkC.copyFrom(_rkC);
-  rkE.copyFrom(_rkE);
-  rkA.copyFrom(_rkA);
-
-  o_rkA = platform.malloc<dfloat>(rkA);
-  o_rkE = platform.malloc<dfloat>(rkE);
-
-  dtMIN = 1E-9; //minumum allowed timestep
-  ATOL = 1E-6;  //absolute error tolerance
-  RTOL = 1E-6;  //relative error tolerance
-  safe = 0.8;   //safety factor
-
-  //error control parameters
-  beta = 0.05;
-  factor1 = 0.2;
-  factor2 = 10.0;
-
-  exp1 = 0.2 - 0.75*beta;
-  invfactor1 = 1.0/factor1;
-  invfactor2 = 1.0/factor2;
-  facold = 1E-4;
-  sqrtinvNtotal = 1.0/sqrt(Ntotal);
-}
-
-void dopri5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloat end) {
-
-  dfloat time = start;
-
-  solver.Report(time,0);
-
-  dfloat outputInterval=0.0;
-  solver.settings.getSetting("OUTPUT INTERVAL", outputInterval);
-
-  dfloat outputTime = time + outputInterval;
-
-  int tstep=0, allStep=0;
-
-  while (time < end) {
-
-    LIBP_ABORT("Time step became too small at time step = " << tstep,
-               dt<dtMIN);
-    LIBP_ABORT("Solution became unstable at time step = " << tstep,
-               std::isnan(dt));
-
-    //check for final timestep
-    if (time+dt > end){
-      dt = end-time;
-    }
-
-    Step(solver, o_q, time, dt);
-
-    // compute Dopri estimator
-    dfloat err = Estimater(o_q);
-
-    // build controller
-    dfloat fac1 = pow(err,exp1);
-    dfloat fac = fac1/pow(facold,beta);
-
-    fac = std::max(invfactor2, std::min(invfactor1,fac/safe));
-    dfloat dtnew = dt/fac;
-
-    if (err<1.0) { //dt is accepted
-
-      // check for output during this step and do a mini-step
-      if (time<outputTime && time+dt>=outputTime) {
-        dfloat savedt = dt;
-
-        // save rkq
-        Backup(o_rkq);
-
-        // change dt to match output
-        dt = outputTime-time;
-
-        // time step to output
-        Step(solver, o_q, time, dt);
-
-        // shift for output
-        o_rkq.copyTo(o_q, properties_t("async", true));
-
-        // output  (print from rkq)
-        // if (!rank) printf("\n");
-        solver.Report(outputTime,tstep);
-
-        // restore time step
-        dt = savedt;
-
-        // increment next output time
-        outputTime += outputInterval;
-
-        // accept saved rkq
-        Restore(o_rkq);
-        AcceptStep(o_q, o_rkq);
-      } else {
-        // accept rkq
-        AcceptStep(o_q, o_rkq);
-      }
-
-      time += dt;
-      while (time>outputTime) outputTime+= outputInterval; //catch up next output in case dt>outputInterval
-
-      constexpr dfloat errMax = 1.0e-4;  // hard coded factor ?
-      facold = std::max(err,errMax);
-
-      tstep++;
-    } else {
-      dtnew = dt/(std::max(invfactor1,fac1/safe));
-    }
-    dt = dtnew;
-    allStep++;
-  }
-}
-
-void dopri5::Backup(deviceMemory<dfloat> &o_Q) {
-  o_saveq.copyFrom(o_Q, N, properties_t("async", true));
-}
-
-void dopri5::Restore(deviceMemory<dfloat> &o_Q) {
-  o_saveq.copyTo(o_Q, N, properties_t("async", true));
-}
-
-void dopri5::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq) {
-  o_q.copyFrom(o_rq, N, properties_t("async", true));
-}
-
-void dopri5::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloat _dt) {
-
-  //RK step
-  for(int rk=0;rk<Nrk;++rk){
-
-    // t_rk = t + C_rk*_dt
-    dfloat currentTime = time + rkC[rk]*_dt;
-
-    //compute RK stage
-    // rkq = q + _dt sum_{i=0}^{rk-1} a_{rk,i}*rhsq_i
-    rkStageKernel(N,
-                  rk,
-                  _dt,
-                  o_rkA,
-                  o_q,
-                  o_rkrhsq,
-                  o_rkq);
-
-    //evaluate ODE rhs = f(q,t)
-    solver.rhsf(o_rkq, o_rhsq, currentTime);
-
-    // update solution using Runge-Kutta
-    // rkrhsq_rk = rhsq
-    // if rk==6
-    //   q = q + _dt*sum_{i=0}^{rk} rkA_{rk,i}*rkrhs_i
-    //   rkerr = _dt*sum_{i=0}^{rk} rkE_{rk,i}*rkrhs_i
-    rkUpdateKernel(N,
-                   rk,
-                   _dt,
-                   o_rkA,
-                   o_rkE,
-                   o_q,
-                   o_rhsq,
-                   o_rkrhsq,
-                   o_rkq,
-                   o_rkerr);
-  }
-}
-
-dfloat dopri5::Estimater(deviceMemory<dfloat>& o_q){
-
-  //Error estimation
-  //E. HAIRER, S.P. NORSETT AND G. WANNER, SOLVING ORDINARY
-  //      DIFFERENTIAL EQUATIONS I. NONSTIFF PROBLEMS. 2ND EDITION.
-  rkErrorEstimateKernel(N,
-                        ATOL,
-                        RTOL,
-                        o_q,
-                        o_rkq,
-                        o_rkerr,
-                        o_errtmp);
-
-  h_errtmp.copyFrom(o_errtmp);
-  dfloat err = 0;
-  for(dlong n=0;n<Nblock;++n){
-    err += h_errtmp[n];
-  }
-  comm.Allreduce(err);
-
-  err = sqrt(err)*sqrtinvNtotal;
-
-  return err;
-}
-
-/**************************************************/
-/* PML version                                    */
-/**************************************************/
-
-dopri5_pml::dopri5_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
-                       int Np, int Nfields, int Npmlfields,
-                       platform_t& _platform, comm_t _comm):
-  pmlTimeStepperBase_t(Nelements, NpmlElements, NhaloElements,
-                       Np, Nfields, Npmlfields,
-                       _platform, _comm) {
+dopri5::dopri5(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
+               int Np, int Nfields, int Npmlfields,
+               platform_t& _platform, comm_t _comm):
+  timeStepperBase_t(Nelements, NpmlElements, NhaloElements,
+                    Np, Nfields, Npmlfields,
+                    _platform, _comm) {
 
   Nrk = 7;
 
@@ -376,10 +132,10 @@ dopri5_pml::dopri5_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
   sqrtinvNtotal = 1.0/sqrt(Ntotal);
 }
 
-void dopri5_pml::Run(solver_t& solver,
-                     deviceMemory<dfloat> &o_q,
-                     deviceMemory<dfloat> &o_pmlq,
-                     dfloat start, dfloat end) {
+void dopri5::Run(solver_t& solver,
+                 deviceMemory<dfloat> o_q,
+                 std::optional<deviceMemory<dfloat>> o_pmlq,
+                 dfloat start, dfloat end) {
 
   dfloat time = start;
 
@@ -423,7 +179,10 @@ void dopri5_pml::Run(solver_t& solver,
         dfloat savedt = dt;
 
         // save rkq
-        Backup(o_rkq, o_rkpmlq);
+        o_saveq.copyFrom(o_rkq, N, properties_t("async", true));
+        if (o_pmlq.has_value()) {
+          o_savepmlq.copyFrom(o_rkpmlq, Npml, properties_t("async", true));
+        }
 
         // change dt to match output
         dt = outputTime-time;
@@ -433,9 +192,11 @@ void dopri5_pml::Run(solver_t& solver,
 
         // shift for output
         o_rkq.copyTo(o_q, properties_t("async", true));
+        if (o_pmlq.has_value()) {
+          o_rkpmlq.copyTo(o_pmlq.value(), properties_t("async", true));
+        }
 
         // output  (print from rkq)
-        // if (!rank) printf("\n");
         solver.Report(outputTime,tstep);
 
         // restore time step
@@ -445,11 +206,16 @@ void dopri5_pml::Run(solver_t& solver,
         outputTime += outputInterval;
 
         // accept saved rkq
-        Restore(o_rkq, o_rkpmlq);
-        AcceptStep(o_q, o_rkq, o_pmlq, o_rkpmlq);
+        o_saveq.copyTo(o_q, N, properties_t("async", true));
+        if (o_pmlq.has_value()) {
+          o_savepmlq.copyTo(o_pmlq.value(), Npml, properties_t("async", true));
+        }
       } else {
         // accept rkq
-        AcceptStep(o_q, o_rkq, o_pmlq, o_rkpmlq);
+        o_q.copyFrom(o_rkq, N, properties_t("async", true));
+        if (o_pmlq.has_value()) {
+          o_pmlq.value().copyFrom(o_rkpmlq, Npml, properties_t("async", true));
+        }
       }
 
       time += dt;
@@ -467,28 +233,11 @@ void dopri5_pml::Run(solver_t& solver,
   }
 }
 
-void dopri5_pml::Backup(deviceMemory<dfloat> &o_q,
-                        deviceMemory<dfloat> &o_pmlq) {
-  o_saveq.copyFrom(o_q, N, properties_t("async", true));
-  o_savepmlq.copyFrom(o_pmlq, Npml, properties_t("async", true));
-}
 
-void dopri5_pml::Restore(deviceMemory<dfloat> &o_q,
-                         deviceMemory<dfloat> &o_pmlq) {
-  o_saveq.copyTo(o_q, N, properties_t("async", true));
-  o_savepmlq.copyTo(o_pmlq, Npml, properties_t("async", true));
-}
-
-void dopri5_pml::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq,
-                            deviceMemory<dfloat> &o_pmlq, deviceMemory<dfloat> &o_rpmlq) {
-  o_q.copyFrom(o_rq, N, properties_t("async", true));
-  o_pmlq.copyFrom(o_rpmlq, Npml, properties_t("async", true));
-}
-
-void dopri5_pml::Step(solver_t& solver,
-                      deviceMemory<dfloat> &o_q,
-                      deviceMemory<dfloat> &o_pmlq,
-                      dfloat time, dfloat _dt) {
+void dopri5::Step(solver_t& solver,
+                  deviceMemory<dfloat> o_q,
+                  std::optional<deviceMemory<dfloat>> o_pmlq,
+                  dfloat time, dfloat _dt) {
 
   //RK step
   for(int rk=0;rk<Nrk;++rk){
@@ -505,16 +254,22 @@ void dopri5_pml::Step(solver_t& solver,
                   o_q,
                   o_rkrhsq,
                   o_rkq);
-    rkStageKernel(Npml,
-                  rk,
-                  _dt,
-                  o_rkA,
-                  o_pmlq,
-                  o_rkrhspmlq,
-                  o_rkpmlq);
+    if (o_pmlq.has_value()) {
+      rkStageKernel(Npml,
+                    rk,
+                    _dt,
+                    o_rkA,
+                    o_pmlq.value(),
+                    o_rkrhspmlq,
+                    o_rkpmlq);
+    }
 
     //evaluate ODE rhs = f(q,t)
-    solver.rhsf_pml(o_rkq, o_rkpmlq, o_rhsq, o_rhspmlq, currentTime);
+    if (o_pmlq.has_value()) {
+      solver.rhsf_pml(o_rkq, o_rkpmlq, o_rhsq, o_rhspmlq, currentTime);
+    } else {
+      solver.rhsf(o_rkq, o_rhsq, currentTime);
+    }
 
     // update solution using Runge-Kutta
     // rkrhsq_rk = rhsq
@@ -531,18 +286,20 @@ void dopri5_pml::Step(solver_t& solver,
                    o_rkrhsq,
                    o_rkq,
                    o_rkerr);
-    rkPmlUpdateKernel(Npml,
-                     rk,
-                     _dt,
-                     o_rkA,
-                     o_pmlq,
-                     o_rhspmlq,
-                     o_rkrhspmlq,
-                     o_rkpmlq);
+    if (o_pmlq.has_value()) {
+      rkPmlUpdateKernel(Npml,
+                       rk,
+                       _dt,
+                       o_rkA,
+                       o_pmlq.value(),
+                       o_rhspmlq,
+                       o_rkrhspmlq,
+                       o_rkpmlq);
+    }
   }
 }
 
-dfloat dopri5_pml::Estimater(deviceMemory<dfloat>& o_q){
+dfloat dopri5::Estimater(deviceMemory<dfloat>& o_q){
 
   //Error estimation
   //E. HAIRER, S.P. NORSETT AND G. WANNER, SOLVING ORDINARY

--- a/libs/timeStepper/timeStepperDOPRI5.cpp
+++ b/libs/timeStepper/timeStepperDOPRI5.cpp
@@ -118,9 +118,6 @@ void dopri5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dflo
 
   dfloat time = start;
 
-  // int rank;
-  // comm_rank_t(comm, &rank);
-
   solver.Report(time,0);
 
   dfloat outputInterval=0.0;
@@ -166,14 +163,11 @@ void dopri5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dflo
         // change dt to match output
         dt = outputTime-time;
 
-        // if(!rank)
-        //   printf("Taking output mini step: %g\n", dt);
-
         // time step to output
         Step(solver, o_q, time, dt);
 
         // shift for output
-        o_rkq.copyTo(o_q);
+        o_rkq.copyTo(o_q, properties_t("async", true));
 
         // output  (print from rkq)
         // if (!rank) printf("\n");
@@ -199,36 +193,25 @@ void dopri5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dflo
       constexpr dfloat errMax = 1.0e-4;  // hard coded factor ?
       facold = std::max(err,errMax);
 
-      // if (!rank)
-      //   printf("\r time = %g (%d), dt = %g accepted                      ", time, allStep,  dt);
-
       tstep++;
     } else {
       dtnew = dt/(std::max(invfactor1,fac1/safe));
-
-      // if (!rank)
-      //   printf("\r time = %g (%d), dt = %g rejected, trying %g", time, allStep, dt, dtnew);
-      // if (!rank)
-      //   printf("Repeating timestep %d. dt was %g, trying %g.\n", tstep, dt, dtnew);
     }
     dt = dtnew;
     allStep++;
   }
-
-  // if (!rank)
-  //   printf("%d accepted steps and %d total steps\n", tstep, allStep);
 }
 
 void dopri5::Backup(deviceMemory<dfloat> &o_Q) {
-  o_saveq.copyFrom(o_Q, N);
+  o_saveq.copyFrom(o_Q, N, properties_t("async", true));
 }
 
 void dopri5::Restore(deviceMemory<dfloat> &o_Q) {
-  o_saveq.copyTo(o_Q, N);
+  o_saveq.copyTo(o_Q, N, properties_t("async", true));
 }
 
 void dopri5::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq) {
-  o_q.copyFrom(o_rq, N);
+  o_q.copyFrom(o_rq, N, properties_t("async", true));
 }
 
 void dopri5::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloat _dt) {
@@ -400,9 +383,6 @@ void dopri5_pml::Run(solver_t& solver,
 
   dfloat time = start;
 
-  // int rank;
-  // comm_rank_t(comm, &rank);
-
   solver.Report(time,0);
 
   dfloat outputInterval=0.0;
@@ -448,14 +428,11 @@ void dopri5_pml::Run(solver_t& solver,
         // change dt to match output
         dt = outputTime-time;
 
-        // if(!rank)
-        //   printf("Taking output mini step: %g\n", dt);
-
         // time step to output
         Step(solver, o_q, o_pmlq, time, dt);
 
         // shift for output
-        o_rkq.copyTo(o_q);
+        o_rkq.copyTo(o_q, properties_t("async", true));
 
         // output  (print from rkq)
         // if (!rank) printf("\n");
@@ -481,42 +458,31 @@ void dopri5_pml::Run(solver_t& solver,
       constexpr dfloat errMax = 1.0e-4;  // hard coded factor ?
       facold = std::max(err,errMax);
 
-      // if (!rank)
-      //   printf("\r time = %g (%d), dt = %g accepted                      ", time, allStep,  dt);
-
       tstep++;
     } else {
       dtnew = dt/(std::max(invfactor1,fac1/safe));
-
-      // if (!rank)
-      //   printf("\r time = %g (%d), dt = %g rejected, trying %g", time, allStep, dt, dtnew);
-      // if (!rank)
-      //   printf("Repeating timestep %d. dt was %g, trying %g.\n", tstep, dt, dtnew);
     }
     dt = dtnew;
     allStep++;
   }
-
-  // if (!rank)
-  //   printf("%d accepted steps and %d total steps\n", tstep, allStep);
 }
 
 void dopri5_pml::Backup(deviceMemory<dfloat> &o_q,
                         deviceMemory<dfloat> &o_pmlq) {
-  o_saveq.copyFrom(o_q, N);
-  o_savepmlq.copyFrom(o_pmlq, Npml);
+  o_saveq.copyFrom(o_q, N, properties_t("async", true));
+  o_savepmlq.copyFrom(o_pmlq, Npml, properties_t("async", true));
 }
 
 void dopri5_pml::Restore(deviceMemory<dfloat> &o_q,
                          deviceMemory<dfloat> &o_pmlq) {
-  o_saveq.copyTo(o_q, N);
-  o_savepmlq.copyTo(o_pmlq, Npml);
+  o_saveq.copyTo(o_q, N, properties_t("async", true));
+  o_savepmlq.copyTo(o_pmlq, Npml, properties_t("async", true));
 }
 
 void dopri5_pml::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq,
                             deviceMemory<dfloat> &o_pmlq, deviceMemory<dfloat> &o_rpmlq) {
-  o_q.copyFrom(o_rq, N);
-  o_pmlq.copyFrom(o_rpmlq, Npml);
+  o_q.copyFrom(o_rq, N, properties_t("async", true));
+  o_pmlq.copyFrom(o_rpmlq, Npml, properties_t("async", true));
 }
 
 void dopri5_pml::Step(solver_t& solver,

--- a/libs/timeStepper/timeStepperEXTBDF3.cpp
+++ b/libs/timeStepper/timeStepperEXTBDF3.cpp
@@ -35,7 +35,8 @@ namespace TimeStepper {
 extbdf3::extbdf3(dlong Nelements, dlong NhaloElements,
                  int Np, int Nfields,
                  platform_t& _platform, comm_t _comm):
-  timeStepperBase_t(Nelements, NhaloElements, Np, Nfields,
+  timeStepperBase_t(Nelements, 0, NhaloElements,
+                    Np, Nfields, 0,
                     _platform, _comm) {
 
   //Nstages = 3;
@@ -81,7 +82,13 @@ dfloat extbdf3::GetGamma() {
   return extbdf_b[(Nstages-1)*(Nstages+1)]; //first entry of last row of B
 }
 
-void extbdf3::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloat end) {
+void extbdf3::Run(solver_t& solver,
+                  deviceMemory<dfloat> o_q,
+                  std::optional<deviceMemory<dfloat>> o_pmlq,
+                  dfloat start, dfloat end) {
+
+  LIBP_ABORT("extbdf3 timeStepper does not support PMLs",
+             o_pmlq.has_value());
 
   dfloat time = start;
 
@@ -108,7 +115,9 @@ void extbdf3::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfl
   }
 }
 
-void extbdf3::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloat _dt, int order) {
+void extbdf3::Step(solver_t& solver,
+                   deviceMemory<dfloat> o_q,
+                   dfloat time, dfloat _dt, int order) {
 
   //F(q) at current index
   deviceMemory<dfloat> o_F0 = o_F + shiftIndex*N;

--- a/libs/timeStepper/timeStepperEXTBDF3.cpp
+++ b/libs/timeStepper/timeStepperEXTBDF3.cpp
@@ -41,13 +41,10 @@ extbdf3::extbdf3(dlong Nelements, dlong NhaloElements,
   //Nstages = 3;
   shiftIndex = 0;
 
-  memory<dfloat> qn(Nstages*N, 0.0);
-  o_qn = platform.malloc<dfloat>(qn); //q history
+  o_qn = platform.malloc<dfloat>(Nstages*N); //q history
+  o_rhs = platform.malloc<dfloat>(N); //rhs storage
 
-  memory<dfloat> rhs(N,0.0);
-  o_rhs = platform.malloc<dfloat>(rhs); //rhs storage
-
-  o_F  = platform.malloc<dfloat>(qn); //F(q) history (explicit part)
+  o_F  = platform.malloc<dfloat>(Nstages*N); //F(q) history (explicit part)
 
   properties_t kernelInfo = platform.props(); //copy base occa properties from solver
 

--- a/libs/timeStepper/timeStepperLSERK4.cpp
+++ b/libs/timeStepper/timeStepperLSERK4.cpp
@@ -34,128 +34,16 @@ namespace TimeStepper {
 lserk4::lserk4(dlong Nelements, dlong NhaloElements,
                int Np, int Nfields,
                platform_t& _platform, comm_t _comm):
-  timeStepperBase_t(Nelements, NhaloElements, Np, Nfields,
+  lserk4(Nelements, 0, NhaloElements,
+         Np, Nfields, 0,
+         _platform, _comm) {}
+
+lserk4::lserk4(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
+               int Np, int Nfields, int Npmlfields,
+               platform_t& _platform, comm_t _comm):
+  timeStepperBase_t(Nelements, NpmlElements, NhaloElements,
+                    Np, Nfields, Npmlfields,
                     _platform, _comm) {
-
-  Nrk = 5;
-
-  o_resq = platform.malloc<dfloat>(N);
-  o_rhsq = platform.malloc<dfloat>(N);
-
-  o_saveq = platform.malloc<dfloat>(N);
-
-  properties_t kernelInfo = platform.props(); //copy base occa properties from solver
-
-  const int blocksize=256;
-
-  kernelInfo["defines/" "p_blockSize"] = blocksize;
-
-  updateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
-                                    "timeStepperLSERK4.okl",
-                                    "lserk4Update",
-                                    kernelInfo);
-
-  // initialize LSERK4 time stepping coefficients
-  dfloat _rka[5] = {0.0,
-       -567301805773.0/1357537059087.0 ,
-       -2404267990393.0/2016746695238.0 ,
-       -3550918686646.0/2091501179385.0  ,
-       -1275806237668.0/842570457699.0};
-  dfloat _rkb[5] = { 1432997174477.0/9575080441755.0 ,
-        5161836677717.0/13612068292357.0 ,
-        1720146321549.0/2090206949498.0  ,
-        3134564353537.0/4481467310338.0  ,
-        2277821191437.0/14882151754819.0};
-  // added one more for advanced time step
-  dfloat _rkc[6] = {0.0  ,
-       1432997174477.0/9575080441755.0 ,
-       2526269341429.0/6820363962896.0 ,
-       2006345519317.0/3224310063776.0 ,
-       2802321613138.0/2924317926251.0 ,
-       1.0};
-
-  rka.malloc(Nrk);
-  rkb.malloc(Nrk);
-  rkc.malloc(Nrk+1);
-  rka.copyFrom(_rka);
-  rkb.copyFrom(_rkb);
-  rkc.copyFrom(_rkc);
-}
-
-void lserk4::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloat end) {
-
-  dfloat time = start;
-
-  solver.Report(time,0);
-
-  dfloat outputInterval=0.0;
-  solver.settings.getSetting("OUTPUT INTERVAL", outputInterval);
-
-  dfloat outputTime = time + outputInterval;
-
-  int tstep=0;
-  dfloat stepdt;
-  while (time < end) {
-
-    if (time<outputTime && time+dt>=outputTime) {
-
-      //save current state
-      o_saveq.copyFrom(o_q, N, properties_t("async", true));
-
-      stepdt = outputTime-time;
-
-      //take small time step
-      Step(solver, o_q, time, stepdt);
-
-      //report state
-      solver.Report(outputTime,tstep);
-
-      //restore previous state
-      o_q.copyFrom(o_saveq, N, properties_t("async", true));
-
-      outputTime += outputInterval;
-    }
-
-    //check for final timestep
-    if (time+dt > end){
-      stepdt = end-time;
-    } else {
-      stepdt = dt;
-    }
-
-    Step(solver, o_q, time, stepdt);
-    time += stepdt;
-    tstep++;
-  }
-}
-
-void lserk4::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloat _dt) {
-
-  // Low storage explicit Runge Kutta (5 stages, 4th order)
-  for(int rk=0;rk<Nrk;++rk){
-
-    dfloat currentTime = time + rkc[rk]*_dt;
-
-    //evaluate ODE rhs = f(q,t)
-    solver.rhsf(o_q, o_rhsq, currentTime);
-
-    // update solution using Runge-Kutta
-    updateKernel(N, _dt, rka[rk], rkb[rk],
-                 o_rhsq, o_resq, o_q);
-  }
-}
-
-
-/**************************************************/
-/* PML version                                    */
-/**************************************************/
-
-lserk4_pml::lserk4_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
-                       int Np, int Nfields, int Npmlfields,
-                       platform_t& _platform, comm_t _comm):
-  pmlTimeStepperBase_t(Nelements, NpmlElements, NhaloElements,
-                       Np, Nfields, Npmlfields,
-                       _platform, _comm) {
 
   Nrk = 5;
 
@@ -205,10 +93,10 @@ lserk4_pml::lserk4_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
   rkc.copyFrom(_rkc);
 }
 
-void lserk4_pml::Run(solver_t& solver,
-                     deviceMemory<dfloat> &o_q,
-                     deviceMemory<dfloat> &o_pmlq,
-                     dfloat start, dfloat end) {
+void lserk4::Run(solver_t& solver,
+                 deviceMemory<dfloat> o_q,
+                 std::optional<deviceMemory<dfloat>> o_pmlq,
+                 dfloat start, dfloat end) {
 
   dfloat time = start;
 
@@ -227,7 +115,9 @@ void lserk4_pml::Run(solver_t& solver,
 
       //save current state
       o_saveq.copyFrom(o_q, N, properties_t("async", true));
-      o_savepmlq.copyFrom(o_pmlq, Npml, properties_t("async", true));
+      if (o_pmlq.has_value()) {
+        o_savepmlq.copyFrom(o_pmlq.value(), Npml, properties_t("async", true));
+      }
 
       stepdt = outputTime-time;
 
@@ -239,7 +129,9 @@ void lserk4_pml::Run(solver_t& solver,
 
       //restore previous state
       o_q.copyFrom(o_saveq, N, properties_t("async", true));
-      o_pmlq.copyFrom(o_savepmlq, Npml, properties_t("async", true));
+      if (o_pmlq.has_value()) {
+        o_pmlq.value().copyFrom(o_savepmlq, Npml, properties_t("async", true));
+      }
 
       outputTime += outputInterval;
     }
@@ -257,10 +149,10 @@ void lserk4_pml::Run(solver_t& solver,
   }
 }
 
-void lserk4_pml::Step(solver_t& solver,
-                      deviceMemory<dfloat> &o_q,
-                      deviceMemory<dfloat> &o_pmlq,
-                      dfloat time, dfloat _dt) {
+void lserk4::Step(solver_t& solver,
+                  deviceMemory<dfloat> o_q,
+                  std::optional<deviceMemory<dfloat>> o_pmlq,
+                  dfloat time, dfloat _dt) {
 
   // Low storage explicit Runge Kutta (5 stages, 4th order)
   for(int rk=0;rk<Nrk;++rk){
@@ -268,13 +160,19 @@ void lserk4_pml::Step(solver_t& solver,
     dfloat currentTime = time + rkc[rk]*_dt;
 
     //evaluate ODE rhs = f(q,t)
-    solver.rhsf_pml(o_q, o_pmlq, o_rhsq, o_rhspmlq, currentTime);
+    if (o_pmlq.has_value()) {
+      solver.rhsf_pml(o_q, o_pmlq.value(), o_rhsq, o_rhspmlq, currentTime);
+    } else {
+      solver.rhsf(o_q, o_rhsq, currentTime);
+    }
 
     // update solution using Runge-Kutta
     updateKernel(N, _dt, rka[rk], rkb[rk],
                  o_rhsq, o_resq, o_q);
-    updateKernel(Npml, _dt, rka[rk], rkb[rk],
-                 o_rhspmlq, o_respmlq, o_pmlq);
+    if (o_pmlq.has_value()) {
+      updateKernel(Npml, _dt, rka[rk], rkb[rk],
+                   o_rhspmlq, o_respmlq, o_pmlq.value());
+    }
   }
 }
 

--- a/libs/timeStepper/timeStepperLSERK4.cpp
+++ b/libs/timeStepper/timeStepperLSERK4.cpp
@@ -100,7 +100,7 @@ void lserk4::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dflo
     if (time<outputTime && time+dt>=outputTime) {
 
       //save current state
-      o_saveq.copyFrom(o_q, N);
+      o_saveq.copyFrom(o_q, N, properties_t("async", true));
 
       stepdt = outputTime-time;
 
@@ -111,7 +111,7 @@ void lserk4::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dflo
       solver.Report(outputTime,tstep);
 
       //restore previous state
-      o_q.copyFrom(o_saveq, N);
+      o_q.copyFrom(o_saveq, N, properties_t("async", true));
 
       outputTime += outputInterval;
     }
@@ -226,8 +226,8 @@ void lserk4_pml::Run(solver_t& solver,
     if (time<outputTime && time+dt>=outputTime) {
 
       //save current state
-      o_saveq.copyFrom(o_q, N);
-      o_savepmlq.copyFrom(o_pmlq, Npml);
+      o_saveq.copyFrom(o_q, N, properties_t("async", true));
+      o_savepmlq.copyFrom(o_pmlq, Npml, properties_t("async", true));
 
       stepdt = outputTime-time;
 
@@ -238,8 +238,8 @@ void lserk4_pml::Run(solver_t& solver,
       solver.Report(outputTime,tstep);
 
       //restore previous state
-      o_q.copyFrom(o_saveq, N);
-      o_pmlq.copyFrom(o_savepmlq, Npml);
+      o_q.copyFrom(o_saveq, N, properties_t("async", true));
+      o_pmlq.copyFrom(o_savepmlq, Npml, properties_t("async", true));
 
       outputTime += outputInterval;
     }

--- a/libs/timeStepper/timeStepperMRAB3.cpp
+++ b/libs/timeStepper/timeStepperMRAB3.cpp
@@ -204,9 +204,7 @@ void mrab3::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloa
                         o_q,
                         o_fQM);
 
-    // o_shiftIndex.copyFrom(h_shiftIndex, properties_t("async", true));
-    h_shiftIndex.copyTo(o_shiftIndex); //Required to keep the update kernel overlapping the transfer,
-                                       // but why does that happen?
+    h_shiftIndex.copyTo(o_shiftIndex, properties_t("async", true));
   }
 }
 
@@ -421,9 +419,7 @@ void mrab3_pml::Step(solver_t& solver,
                         o_q,
                         o_fQM);
 
-    // o_shiftIndex.copyFrom(h_shiftIndex, properties_t("async", true));
-    h_shiftIndex.copyTo(o_shiftIndex); //Required to keep the update kernel overlapping the transfer,
-                                       // but why does that happen?
+    h_shiftIndex.copyTo(o_shiftIndex, properties_t("async", true));
   }
 }
 

--- a/libs/timeStepper/timeStepperMRAB3.cpp
+++ b/libs/timeStepper/timeStepperMRAB3.cpp
@@ -42,11 +42,8 @@ mrab3::mrab3(dlong Nelements, dlong NhaloElements,
 
   //Nstages = 3;
 
-  memory<dfloat> rhsq0(N, 0.0);
-  o_rhsq0 = platform.malloc<dfloat>(rhsq0);
-
-  memory<dfloat> rhsq((Nstages-1)*N, 0.0);
-  o_rhsq = platform.malloc<dfloat>(rhsq);
+  o_rhsq0 = platform.malloc<dfloat>(N);
+  o_rhsq = platform.malloc<dfloat>((Nstages-1)*N);
 
   o_fQM = platform.malloc<dfloat>((mesh.Nelements+mesh.totalHaloPairs)*mesh.Nfp
                                   *mesh.Nfaces*Nfields);
@@ -96,6 +93,9 @@ mrab3::mrab3(dlong Nelements, dlong NhaloElements,
 
   o_ab_a = platform.malloc<dfloat>(ab_a);
   o_ab_b = platform.malloc<dfloat>(ab_b);
+
+  memory<dfloat> zeros(Nstages, 0.0);
+  o_zeros = platform.malloc<dfloat>(zeros);
 }
 
 void mrab3::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloat end) {
@@ -125,7 +125,7 @@ void mrab3::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
                     N,
                     o_shiftIndex,
                     o_mrdt,
-                    o_ab_b,
+                    o_zeros,
                     o_rhsq0,
                     o_rhsq,
                     o_q,
@@ -225,17 +225,11 @@ mrab3_pml::mrab3_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
 
   //Nstages = 3;
 
-  memory<dfloat> rhsq0(N, 0.0);
-  o_rhsq0 = platform.malloc<dfloat>(rhsq0);
+  o_rhsq0 = platform.malloc<dfloat>(N);
+  o_rhsq = platform.malloc<dfloat>((Nstages-1)*N);
 
-  memory<dfloat> rhsq((Nstages-1)*N, 0.0);
-  o_rhsq = platform.malloc<dfloat>(rhsq);
-
-  memory<dfloat> rhspmlq0(Npml, 0.0);
-  o_rhspmlq0 = platform.malloc<dfloat>(rhspmlq0);
-
-  memory<dfloat> rhspmlq((Nstages-1)*Npml, 0.0);
-  o_rhspmlq = platform.malloc<dfloat>(rhspmlq);
+  o_rhspmlq0 = platform.malloc<dfloat>(Npml);
+  o_rhspmlq = platform.malloc<dfloat>((Nstages-1)*Npml);
 
   o_fQM = platform.malloc<dfloat>((mesh.Nelements+mesh.totalHaloPairs)*mesh.Nfp
                                   *mesh.Nfaces*Nfields);
@@ -271,7 +265,7 @@ mrab3_pml::mrab3_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
                            1.0,      0.0,    0.0,
                          3./2.,   -1./2.,    0.0,
                        23./12., -16./12., 5./12.};
-  dfloat _ab_b[Nstages*Nstages] = {
+  dfloat _ab_b[(Nstages+1)*Nstages] = {
                          1./2.,      0.0,    0.0,
                          5./8.,   -1./8.,    0.0,
                        17./24.,  -7./24., 2./24.};
@@ -289,6 +283,9 @@ mrab3_pml::mrab3_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
 
   o_ab_a = platform.malloc<dfloat>(ab_a);
   o_ab_b = platform.malloc<dfloat>(ab_b);
+
+  memory<dfloat> zeros(Nstages, 0.0);
+  o_zeros = platform.malloc<dfloat>(zeros);
 }
 
 void mrab3_pml::Run(solver_t& solver,
@@ -321,7 +318,7 @@ void mrab3_pml::Run(solver_t& solver,
                     N,
                     o_shiftIndex,
                     o_mrdt,
-                    o_ab_b,
+                    o_zeros,
                     o_rhsq0,
                     o_rhsq,
                     o_q,

--- a/libs/timeStepper/timeStepperMRAB3.cpp
+++ b/libs/timeStepper/timeStepperMRAB3.cpp
@@ -215,44 +215,142 @@ void mrab3::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloa
 /**************************************************/
 
 mrab3_pml::mrab3_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
-                     int Np, int _Nfields, int _Npmlfields,
+                     int _Np, int _Nfields, int _Npmlfields,
                      platform_t& _platform, mesh_t& _mesh):
-  mrab3(Nelements, NhaloElements,
-        Np, _Nfields, _platform, _mesh),
-  Npml(NpmlElements*Np*_Npmlfields),
+  pmlTimeStepperBase_t(Nelements, NpmlElements, NhaloElements,
+                       _Np, _Nfields, _Npmlfields,
+                       _platform, _mesh.comm),
+  mesh(_mesh),
+  Nlevels(mesh.mrNlevels),
+  Nfields(_Nfields),
   Npmlfields(_Npmlfields) {
 
-  if (Npml) {
-    memory<dfloat> pmlq(Npml, 0.0);
-    o_pmlq = platform.malloc<dfloat>(pmlq);
+  //Nstages = 3;
 
-    memory<dfloat> rhspmlq0(Npml, 0.0);
-    o_rhspmlq0 = platform.malloc<dfloat>(rhspmlq0);
+  memory<dfloat> rhsq0(N, 0.0);
+  o_rhsq0 = platform.malloc<dfloat>(rhsq0);
 
-    memory<dfloat> rhspmlq((Nstages-1)*Npml, 0.0);
-    o_rhspmlq = platform.malloc<dfloat>(rhspmlq);
+  memory<dfloat> rhsq((Nstages-1)*N, 0.0);
+  o_rhsq = platform.malloc<dfloat>(rhsq);
 
-    properties_t kernelInfo = platform.props(); //copy base occa properties from solver
+  memory<dfloat> rhspmlq0(Npml, 0.0);
+  o_rhspmlq0 = platform.malloc<dfloat>(rhspmlq0);
 
-    const int blocksize=256;
+  memory<dfloat> rhspmlq((Nstages-1)*Npml, 0.0);
+  o_rhspmlq = platform.malloc<dfloat>(rhspmlq);
 
-    kernelInfo["defines/" "p_blockSize"] = blocksize;
-    kernelInfo["defines/" "p_Nstages"] = Nstages;
-    kernelInfo["defines/" "p_Np"] = mesh.Np;
-    kernelInfo["defines/" "p_Nfp"] = mesh.Nfp;
-    kernelInfo["defines/" "p_Nfaces"] = mesh.Nfaces;
-    kernelInfo["defines/" "p_Nfields"] = Nfields;
-    int maxNodes = std::max(mesh.Np, mesh.Nfp*mesh.Nfaces);
-    kernelInfo["defines/" "p_maxNodes"] = maxNodes;
+  o_fQM = platform.malloc<dfloat>((mesh.Nelements+mesh.totalHaloPairs)*mesh.Nfp
+                                  *mesh.Nfaces*Nfields);
 
-    pmlUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+  properties_t kernelInfo = platform.props(); //copy base occa properties from solver
+
+  const int blocksize=256;
+
+  kernelInfo["defines/" "p_blockSize"] = blocksize;
+  kernelInfo["defines/" "p_Nstages"] = Nstages;
+  kernelInfo["defines/" "p_Np"] = mesh.Np;
+  kernelInfo["defines/" "p_Nfp"] = mesh.Nfp;
+  kernelInfo["defines/" "p_Nfaces"] = mesh.Nfaces;
+  kernelInfo["defines/" "p_Nfields"] = Nfields;
+  int maxNodes = std::max(mesh.Np, mesh.Nfp*mesh.Nfaces);
+  kernelInfo["defines/" "p_maxNodes"] = maxNodes;
+
+  updateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+                                    "timeStepperMRAB.okl",
+                                    "mrabUpdate",
+                                    kernelInfo);
+  pmlUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
                                       "timeStepperMRAB.okl",
                                       "mrabPmlUpdate",
                                       kernelInfo);
+  traceUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+                                    "timeStepperMRAB.okl",
+                                    "mrabTraceUpdate",
+                                    kernelInfo);
+
+  // initialize AB time stepping coefficients
+  dfloat _ab_a[Nstages*Nstages] = {
+                           1.0,      0.0,    0.0,
+                         3./2.,   -1./2.,    0.0,
+                       23./12., -16./12., 5./12.};
+  dfloat _ab_b[Nstages*Nstages] = {
+                         1./2.,      0.0,    0.0,
+                         5./8.,   -1./8.,    0.0,
+                       17./24.,  -7./24., 2./24.};
+
+  ab_a.malloc(Nstages*Nstages);
+  ab_b.malloc(Nstages*Nstages);
+  ab_a.copyFrom(_ab_a);
+  ab_b.copyFrom(_ab_b);
+
+  h_shiftIndex = platform.hostMalloc<int>(Nlevels);
+  o_shiftIndex = platform.malloc<int>(Nlevels);
+
+  mrdt.malloc(Nlevels, 0.0);
+  o_mrdt = platform.malloc<dfloat>(mrdt);
+
+  o_ab_a = platform.malloc<dfloat>(ab_a);
+  o_ab_b = platform.malloc<dfloat>(ab_b);
+}
+
+void mrab3_pml::Run(solver_t& solver,
+                    deviceMemory<dfloat> &o_q,
+                    deviceMemory<dfloat> &o_pmlq,
+                    dfloat start, dfloat end) {
+
+  dfloat time = start;
+
+  //set timesteps and shifting index
+  for (int lev=0;lev<Nlevels;lev++) {
+    mrdt[lev] = dt*(1 << lev);
+    h_shiftIndex[lev] = 0;
+  }
+  o_mrdt.copyFrom(mrdt);
+  h_shiftIndex.copyTo(o_shiftIndex);
+
+  solver.Report(time,0);
+
+  dfloat outputInterval=0.0;
+  solver.settings.getSetting("OUTPUT INTERVAL", outputInterval);
+
+  dfloat outputTime = time + outputInterval;
+
+  // Populate Trace Buffer
+  traceUpdateKernel(mesh.mrNelements[Nlevels-1],
+                    mesh.o_mrElements[Nlevels-1],
+                    mesh.o_mrLevel,
+                    mesh.o_vmapM,
+                    N,
+                    o_shiftIndex,
+                    o_mrdt,
+                    o_ab_b,
+                    o_rhsq0,
+                    o_rhsq,
+                    o_q,
+                    o_fQM);
+
+  dfloat DT = dt*(1 << (Nlevels-1));
+
+  int tstep=0;
+  int order=0;
+  while (time < end) {
+    Step(solver, o_q, o_pmlq, time, dt, order);
+    time += DT;
+    tstep++;
+    if (order<Nstages-1) order++;
+
+    if (time>outputTime) {
+      //report state
+      solver.Report(outputTime,tstep);
+      outputTime += outputInterval;
+    }
   }
 }
 
-void mrab3_pml::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloat _dt, int order) {
+void mrab3_pml::Step(solver_t& solver,
+                     deviceMemory<dfloat> &o_q,
+                     deviceMemory<dfloat> &o_pmlq,
+                     dfloat time, dfloat _dt, int order) {
 
   deviceMemory<dfloat> o_A = o_ab_a+order*Nstages;
   deviceMemory<dfloat> o_B = o_ab_b+order*Nstages;

--- a/libs/timeStepper/timeStepperMRSAAB3.cpp
+++ b/libs/timeStepper/timeStepperMRSAAB3.cpp
@@ -34,6 +34,14 @@ namespace TimeStepper {
 
 using std::complex;
 
+static void UpdateCoefficients(const int Nfields,
+                               const memory<dfloat> &lambda,
+                               const int Nlevels,
+                               const dfloat dt,
+                               pinnedMemory<dfloat> &saab_x,
+                               pinnedMemory<dfloat> &saab_a,
+                               pinnedMemory<dfloat> &saab_b);
+
 mrsaab3::mrsaab3(dlong _Nelements, dlong _NhaloElements,
              int _Np, int _Nfields,
              memory<dfloat> _lambda,
@@ -80,15 +88,15 @@ mrsaab3::mrsaab3(dlong _Nelements, dlong _NhaloElements,
                                     "mrsaabTraceUpdate",
                                     kernelInfo);
 
-  saab_x.malloc(Nlevels*Nfields);
-  saab_a.malloc(Nlevels*Nfields*Nstages*Nstages);
-  saab_b.malloc(Nlevels*Nfields*Nstages*Nstages);
-
   h_shiftIndex = platform.hostMalloc<int>(Nlevels);
   o_shiftIndex = platform.malloc<int>(Nlevels);
 
   mrdt.malloc(Nlevels, 0.0);
   o_mrdt = platform.malloc<dfloat>(mrdt);
+
+  h_saab_x = platform.hostMalloc<dfloat>(Nlevels*Nfields);
+  h_saab_a = platform.hostMalloc<dfloat>(Nlevels*Nfields*Nstages*Nstages);
+  h_saab_b = platform.hostMalloc<dfloat>(Nlevels*Nfields*Nstages*Nstages);
 
   o_saab_x = platform.malloc<dfloat>(Nlevels*Nfields);
   o_saab_a = platform.malloc<dfloat>(Nlevels*Nfields*Nstages*Nstages);
@@ -115,7 +123,12 @@ void mrsaab3::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfl
   dfloat outputTime = time + outputInterval;
 
   //Compute coefficients
-  UpdateCoefficients();
+  UpdateCoefficients(Nfields, lambda, Nlevels, dt, h_saab_x, h_saab_a, h_saab_b);
+
+  // move data to platform
+  h_saab_x.copyTo(o_saab_x);
+  h_saab_a.copyTo(o_saab_a);
+  h_saab_b.copyTo(o_saab_b);
 
   // Populate Trace Buffer
   traceUpdateKernel(mesh.mrNelements[Nlevels-1],
@@ -214,7 +227,13 @@ void mrsaab3::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfl
 }
 
 
-void mrsaab3::UpdateCoefficients() {
+static void UpdateCoefficients(const int Nfields,
+                               const memory<dfloat> &lambda,
+                               const int Nlevels,
+                               const dfloat dt,
+                               pinnedMemory<dfloat> &saab_x,
+                               pinnedMemory<dfloat> &saab_a,
+                               pinnedMemory<dfloat> &saab_b) {
 
   const int Nr = 32;
   complex<dfloat> R[Nr];
@@ -230,21 +249,21 @@ void mrsaab3::UpdateCoefficients() {
 
     for (int n=0;n<Nfields;n++) {
 
+      dfloat* X = saab_x.ptr() + n         + lev * Nfields;
+      dfloat* A = saab_a.ptr() + n * 3 * 3 + lev * Nfields * 3 * 3;
+      dfloat* B = saab_b.ptr() + n * 3 * 3 + lev * Nfields * 3 * 3;
+
       if (lambda[n]==0) { //Zero exponential term, usual AB coefficients
 
-        dfloat _saab_X[1]  = { 1.0 };
-        dfloat _saab_A[Nstages*Nstages]
-                      = {    1.0,      0.0,    0.0,
-                           3./2.,   -1./2.,    0.0,
-                         23./12., -16./12., 5./12.};
-        dfloat _saab_B[Nstages*Nstages] = {
-                           1./2.,      0.0,    0.0,
-                           5./8.,   -1./8.,    0.0,
-                         17./24.,  -7./24., 2./24.};
+        X[0]  = 1.0;
 
-        saab_x.copyFrom(_saab_X,               1, n                +lev*Nfields);
-        saab_a.copyFrom(_saab_A, Nstages*Nstages, n*Nstages*Nstages+lev*Nfields*Nstages*Nstages);
-        saab_b.copyFrom(_saab_B, Nstages*Nstages, n*Nstages*Nstages+lev*Nfields*Nstages*Nstages);
+        A[0 + 0*3] =      1.; A[1 + 0*3] =       0.; A[2 + 0*3]=     0.;
+        A[0 + 1*3] =   3./2.; A[1 + 1*3] =   -1./2.; A[2 + 1*3]=     0.;
+        A[0 + 2*3] = 23./12.; A[1 + 2*3] = -16./12.; A[2 + 2*3]= 5./12.;
+
+        B[0 + 0*3] =   1./2.; B[1 + 0*3] =      0.; B[2 + 0*3]=     0.;
+        B[0 + 1*3] =   5./8.; B[1 + 1*3] =  -1./8.; B[2 + 1*3]=     0.;
+        B[0 + 2*3] = 17./24.; B[1 + 2*3] = -7./24.; B[2 + 2*3]= 2./24.;
 
       } else {
 
@@ -302,26 +321,17 @@ void mrsaab3::UpdateCoefficients() {
         dfloat bb32=real(b32)/ (double) Nr;
         dfloat bb33=real(b33)/ (double) Nr;
 
-        dfloat _saab_X[1]  = { std::exp(alpha) };
-        dfloat _saab_A[Nstages*Nstages]
-                        ={   aa11,   0.0,   0.0,
-                             aa21,  aa22,   0.0,
-                             aa31,  aa32,  aa33 };
-        dfloat _saab_B[Nstages*Nstages]
-                        ={   bb11,   0.0,   0.0,
-                             bb21,  bb22,   0.0,
-                             bb31,  bb32,  bb33 };
+        X[0] = std::exp(alpha);
 
-        saab_x.copyFrom(_saab_X,               1, n                +lev*Nfields);
-        saab_a.copyFrom(_saab_A, Nstages*Nstages, n*Nstages*Nstages+lev*Nfields*Nstages*Nstages);
-        saab_b.copyFrom(_saab_B, Nstages*Nstages, n*Nstages*Nstages+lev*Nfields*Nstages*Nstages);
+        A[0 + 0*3] = aa11; A[1 + 0*3] =   0.; A[2 + 0*3]=   0.;
+        A[0 + 1*3] = aa21; A[1 + 1*3] = aa22; A[2 + 1*3]=   0.;
+        A[0 + 2*3] = aa31; A[1 + 2*3] = aa32; A[2 + 2*3]= aa33;
+
+        B[0 + 0*3] = bb11; B[1 + 0*3] =   0.; B[2 + 0*3]=   0.;
+        B[0 + 1*3] = bb21; B[1 + 1*3] = bb22; B[2 + 1*3]=   0.;
+        B[0 + 2*3] = bb31; B[1 + 2*3] = bb32; B[2 + 2*3]= bb33;
       }
     }
-
-    // move data to platform
-    o_saab_x.copyFrom(saab_x);
-    o_saab_a.copyFrom(saab_a);
-    o_saab_b.copyFrom(saab_b);
   }
 }
 
@@ -329,64 +339,164 @@ void mrsaab3::UpdateCoefficients() {
 /* PML version                                    */
 /**************************************************/
 
-mrsaab3_pml::mrsaab3_pml(dlong Nelements, dlong NpmlElements, dlong NhaloElements,
-                         int Np, int _Nfields, int _Npmlfields,
+mrsaab3_pml::mrsaab3_pml(dlong _Nelements, dlong NpmlElements, dlong _NhaloElements,
+                         int _Np, int _Nfields, int _Npmlfields,
                          memory<dfloat> _lambda,
                          platform_t& _platform, mesh_t& _mesh):
-  mrsaab3(Nelements, NhaloElements,
-          Np, _Nfields, _lambda, _platform, _mesh),
-  Npml(NpmlElements*Np*_Npmlfields),
+  pmlTimeStepperBase_t(_Nelements, NpmlElements, _NhaloElements,
+                       _Np, _Nfields, _Npmlfields,
+                       _platform, _mesh.comm),
+  mesh(_mesh),
+  Nlevels(mesh.mrNlevels),
+  Nfields(_Nfields),
   Npmlfields(_Npmlfields) {
 
-  if (Npml) {
-    memory<dfloat> pmlq(Npml, 0.0);
-    o_pmlq = platform.malloc<dfloat>(pmlq);
+  lambda.malloc(Nfields);
+  lambda.copyFrom(_lambda);
 
-    memory<dfloat> rhspmlq0(Npml, 0.0);
-    o_rhspmlq0 = platform.malloc<dfloat>(rhspmlq0);
+  //Nstages = 3;
 
-    memory<dfloat> rhspmlq((Nstages-1)*Npml, 0.0);
-    o_rhspmlq = platform.malloc<dfloat>(rhspmlq);
+  memory<dfloat> rhsq0(N, 0.0);
+  o_rhsq0 = platform.malloc<dfloat>(rhsq0);
 
-    properties_t kernelInfo = platform.props(); //copy base occa properties from solver
+  memory<dfloat> rhsq((Nstages-1)*N, 0.0);
+  o_rhsq = platform.malloc<dfloat>(rhsq);
 
-    const int blocksize=256;
+  memory<dfloat> rhspmlq0(Npml, 0.0);
+  o_rhspmlq0 = platform.malloc<dfloat>(rhspmlq0);
 
-    kernelInfo["defines/" "p_blockSize"] = blocksize;
-    kernelInfo["defines/" "p_Nstages"] = Nstages;
-    kernelInfo["defines/" "p_Np"] = mesh.Np;
-    kernelInfo["defines/" "p_Nfp"] = mesh.Nfp;
-    kernelInfo["defines/" "p_Nfaces"] = mesh.Nfaces;
-    kernelInfo["defines/" "p_Nfields"] = Nfields;
-    int maxNodes = std::max(mesh.Np, mesh.Nfp*mesh.Nfaces);
-    kernelInfo["defines/" "p_maxNodes"] = maxNodes;
+  memory<dfloat> rhspmlq((Nstages-1)*Npml, 0.0);
+  o_rhspmlq = platform.malloc<dfloat>(rhspmlq);
 
-    pmlUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+  o_fQM = platform.malloc<dfloat>((mesh.Nelements+mesh.totalHaloPairs)*mesh.Nfp
+                                  *mesh.Nfaces*Nfields);
+
+  properties_t kernelInfo = platform.props(); //copy base occa properties from solver
+
+  const int blocksize=256;
+
+  kernelInfo["defines/" "p_blockSize"] = blocksize;
+  kernelInfo["defines/" "p_Nstages"] = Nstages;
+  kernelInfo["defines/" "p_Np"] = mesh.Np;
+  kernelInfo["defines/" "p_Nfp"] = mesh.Nfp;
+  kernelInfo["defines/" "p_Nfaces"] = mesh.Nfaces;
+  kernelInfo["defines/" "p_Nfields"] = Nfields;
+  int maxNodes = std::max(mesh.Np, mesh.Nfp*mesh.Nfaces);
+  kernelInfo["defines/" "p_maxNodes"] = maxNodes;
+
+  updateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+                                    "timeStepperMRSAAB.okl",
+                                    "mrsaabUpdate",
+                                    kernelInfo);
+  pmlUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
                                       "timeStepperMRSAAB.okl",
                                       "mrsaabPmlUpdate",
                                       kernelInfo);
+  traceUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+                                    "timeStepperMRSAAB.okl",
+                                    "mrsaabTraceUpdate",
+                                    kernelInfo);
 
-    // initialize AB time stepping coefficients
-    dfloat _ab_a[Nstages*Nstages] = {
-                             1.0,      0.0,    0.0,
-                           3./2.,   -1./2.,    0.0,
-                         23./12., -16./12., 5./12.};
-    dfloat _ab_b[Nstages*Nstages] = {
-                           1./2.,      0.0,    0.0,
-                           5./8.,   -1./8.,    0.0,
-                         17./24.,  -7./24., 2./24.};
+  h_shiftIndex = platform.hostMalloc<int>(Nlevels);
+  o_shiftIndex = platform.malloc<int>(Nlevels);
 
-    pmlsaab_a.malloc(Nstages*Nstages);
-    pmlsaab_b.malloc(Nstages*Nstages);
-    pmlsaab_a.copyFrom(_ab_a);
-    pmlsaab_b.copyFrom(_ab_b);
+  mrdt.malloc(Nlevels, 0.0);
+  o_mrdt = platform.malloc<dfloat>(mrdt);
 
-    o_pmlsaab_a = platform.malloc<dfloat>(pmlsaab_a);
-    o_pmlsaab_b = platform.malloc<dfloat>(pmlsaab_b);
+  h_saab_x = platform.hostMalloc<dfloat>(Nlevels*Nfields);
+  h_saab_a = platform.hostMalloc<dfloat>(Nlevels*Nfields*Nstages*Nstages);
+  h_saab_b = platform.hostMalloc<dfloat>(Nlevels*Nfields*Nstages*Nstages);
+
+  o_saab_x = platform.malloc<dfloat>(Nlevels*Nfields);
+  o_saab_a = platform.malloc<dfloat>(Nlevels*Nfields*Nstages*Nstages);
+  o_saab_b = platform.malloc<dfloat>(Nlevels*Nfields*Nstages*Nstages);
+
+  // initialize AB time stepping coefficients
+  dfloat _ab_a[Nstages*Nstages] = {
+                           1.0,      0.0,    0.0,
+                         3./2.,   -1./2.,    0.0,
+                       23./12., -16./12., 5./12.};
+  dfloat _ab_b[Nstages*Nstages] = {
+                         1./2.,      0.0,    0.0,
+                         5./8.,   -1./8.,    0.0,
+                       17./24.,  -7./24., 2./24.};
+
+  pmlsaab_a.malloc(Nstages*Nstages);
+  pmlsaab_b.malloc(Nstages*Nstages);
+  pmlsaab_a.copyFrom(_ab_a);
+  pmlsaab_b.copyFrom(_ab_b);
+
+  o_pmlsaab_a = platform.malloc<dfloat>(pmlsaab_a);
+  o_pmlsaab_b = platform.malloc<dfloat>(pmlsaab_b);
+}
+
+void mrsaab3_pml::Run(solver_t& solver,
+                      deviceMemory<dfloat> &o_q,
+                      deviceMemory<dfloat> &o_pmlq,
+                      dfloat start, dfloat end) {
+
+  dfloat time = start;
+
+  //set timesteps and shifting index
+  for (int lev=0;lev<Nlevels;lev++) {
+    mrdt[lev] = dt*(1 << lev);
+    h_shiftIndex[lev] = 0;
+  }
+  o_mrdt.copyFrom(mrdt);
+  h_shiftIndex.copyTo(o_shiftIndex);
+
+  solver.Report(time,0);
+
+  dfloat outputInterval=0.0;
+  solver.settings.getSetting("OUTPUT INTERVAL", outputInterval);
+
+  dfloat outputTime = time + outputInterval;
+
+  //Compute coefficients
+  UpdateCoefficients(Nfields, lambda, Nlevels, dt, h_saab_x, h_saab_a, h_saab_b);
+
+  // move data to platform
+  h_saab_x.copyTo(o_saab_x);
+  h_saab_a.copyTo(o_saab_a);
+  h_saab_b.copyTo(o_saab_b);
+
+  // Populate Trace Buffer
+  traceUpdateKernel(mesh.mrNelements[Nlevels-1],
+                    mesh.o_mrElements[Nlevels-1],
+                    mesh.o_mrLevel,
+                    mesh.o_vmapM,
+                    N,
+                    o_shiftIndex,
+                    o_mrdt,
+                    o_saab_x,
+                    o_saab_b,
+                    o_rhsq0,
+                    o_rhsq,
+                    o_q,
+                    o_fQM);
+
+  dfloat DT = dt*(1 << (Nlevels-1));
+
+  int tstep=0;
+  int order=0;
+  while (time < end) {
+    Step(solver, o_q, o_pmlq, time, dt, order);
+    time += DT;
+    tstep++;
+    if (order<Nstages-1) order++;
+
+    if (time>outputTime) {
+      //report state
+      solver.Report(outputTime,tstep);
+      outputTime += outputInterval;
+    }
   }
 }
 
-void mrsaab3_pml::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloat _dt, int order) {
+void mrsaab3_pml::Step(solver_t& solver,
+                       deviceMemory<dfloat> &o_q,
+                       deviceMemory<dfloat> &o_pmlq,
+                       dfloat time, dfloat _dt, int order) {
 
   deviceMemory<dfloat> o_A = o_saab_a+order*Nstages;
   deviceMemory<dfloat> o_B = o_saab_b+order*Nstages;

--- a/libs/timeStepper/timeStepperMRSAAB3.cpp
+++ b/libs/timeStepper/timeStepperMRSAAB3.cpp
@@ -126,9 +126,9 @@ void mrsaab3::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfl
   UpdateCoefficients(Nfields, lambda, Nlevels, dt, h_saab_x, h_saab_a, h_saab_b);
 
   // move data to platform
-  h_saab_x.copyTo(o_saab_x);
-  h_saab_a.copyTo(o_saab_a);
-  h_saab_b.copyTo(o_saab_b);
+  h_saab_x.copyTo(o_saab_x, properties_t("async", true));
+  h_saab_a.copyTo(o_saab_a, properties_t("async", true));
+  h_saab_b.copyTo(o_saab_b, properties_t("async", true));
 
   // Populate Trace Buffer
   traceUpdateKernel(mesh.mrNelements[Nlevels-1],
@@ -220,9 +220,7 @@ void mrsaab3::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfl
                         o_q,
                         o_fQM);
 
-    // o_shiftIndex.copyFrom(h_shiftIndex, properties_t("async", true));
-    h_shiftIndex.copyTo(o_shiftIndex); //Required to keep the update kernel overlapping the transfer,
-                                       // but why does that happen?
+    h_shiftIndex.copyTo(o_shiftIndex, properties_t("async", true));
   }
 }
 
@@ -456,9 +454,9 @@ void mrsaab3_pml::Run(solver_t& solver,
   UpdateCoefficients(Nfields, lambda, Nlevels, dt, h_saab_x, h_saab_a, h_saab_b);
 
   // move data to platform
-  h_saab_x.copyTo(o_saab_x);
-  h_saab_a.copyTo(o_saab_a);
-  h_saab_b.copyTo(o_saab_b);
+  h_saab_x.copyTo(o_saab_x, properties_t("async", true));
+  h_saab_a.copyTo(o_saab_a, properties_t("async", true));
+  h_saab_b.copyTo(o_saab_b, properties_t("async", true));
 
   // Populate Trace Buffer
   traceUpdateKernel(mesh.mrNelements[Nlevels-1],
@@ -572,9 +570,7 @@ void mrsaab3_pml::Step(solver_t& solver,
                         o_q,
                         o_fQM);
 
-    // o_shiftIndex.copyFrom(h_shiftIndex, properties_t("async", true));
-    h_shiftIndex.copyTo(o_shiftIndex); //Required to keep the update kernel overlapping the transfer,
-                                       // but why does that happen?
+    h_shiftIndex.copyTo(o_shiftIndex, properties_t("async", true));
   }
 }
 

--- a/libs/timeStepper/timeStepperMRSAAB3.cpp
+++ b/libs/timeStepper/timeStepperMRSAAB3.cpp
@@ -34,316 +34,21 @@ namespace TimeStepper {
 
 using std::complex;
 
-static void UpdateCoefficients(const int Nfields,
-                               const memory<dfloat> &lambda,
-                               const int Nlevels,
-                               const dfloat dt,
-                               pinnedMemory<dfloat> &saab_x,
-                               pinnedMemory<dfloat> &saab_a,
-                               pinnedMemory<dfloat> &saab_b);
-
 mrsaab3::mrsaab3(dlong _Nelements, dlong _NhaloElements,
-             int _Np, int _Nfields,
-             memory<dfloat> _lambda,
-             platform_t& _platform, mesh_t& _mesh):
-  timeStepperBase_t(_Nelements, _NhaloElements, _Np, _Nfields,
+                 int _Np, int _Nfields,
+                 memory<dfloat> _lambda,
+                 platform_t& _platform, mesh_t& _mesh):
+  mrsaab3(_Nelements, 0, _NhaloElements,
+          _Np, _Nfields, 0,
+          _lambda, _platform, _mesh) {}
+
+mrsaab3::mrsaab3(dlong _Nelements, dlong NpmlElements, dlong _NhaloElements,
+                 int _Np, int _Nfields, int _Npmlfields,
+                 memory<dfloat> _lambda,
+                 platform_t& _platform, mesh_t& _mesh):
+  timeStepperBase_t(_Nelements, NpmlElements, _NhaloElements,
+                    _Np, _Nfields, _Npmlfields,
                     _platform, _mesh.comm),
-  mesh(_mesh),
-  Nlevels(mesh.mrNlevels),
-  Nfields(_Nfields) {
-
-  lambda.malloc(Nfields);
-  lambda.copyFrom(_lambda);
-
-  //Nstages = 3;
-
-  o_rhsq0 = platform.malloc<dfloat>(N);
-  o_rhsq = platform.malloc<dfloat>((Nstages-1)*N);
-
-  o_fQM = platform.malloc<dfloat>((mesh.Nelements+mesh.totalHaloPairs)*mesh.Nfp
-                                  *mesh.Nfaces*Nfields);
-
-  properties_t kernelInfo = platform.props(); //copy base occa properties from solver
-
-  const int blocksize=256;
-
-  kernelInfo["defines/" "p_blockSize"] = blocksize;
-  kernelInfo["defines/" "p_Nstages"] = Nstages;
-  kernelInfo["defines/" "p_Np"] = mesh.Np;
-  kernelInfo["defines/" "p_Nfp"] = mesh.Nfp;
-  kernelInfo["defines/" "p_Nfaces"] = mesh.Nfaces;
-  kernelInfo["defines/" "p_Nfields"] = Nfields;
-  int maxNodes = std::max(mesh.Np, mesh.Nfp*mesh.Nfaces);
-  kernelInfo["defines/" "p_maxNodes"] = maxNodes;
-
-  updateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
-                                    "timeStepperMRSAAB.okl",
-                                    "mrsaabUpdate",
-                                    kernelInfo);
-  traceUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
-                                    "timeStepperMRSAAB.okl",
-                                    "mrsaabTraceUpdate",
-                                    kernelInfo);
-
-  h_shiftIndex = platform.hostMalloc<int>(Nlevels);
-  o_shiftIndex = platform.malloc<int>(Nlevels);
-
-  mrdt.malloc(Nlevels, 0.0);
-  o_mrdt = platform.malloc<dfloat>(mrdt);
-
-  h_saab_x = platform.hostMalloc<dfloat>(Nlevels*Nfields);
-  h_saab_a = platform.hostMalloc<dfloat>(Nlevels*Nfields*Nstages*Nstages);
-  h_saab_b = platform.hostMalloc<dfloat>(Nlevels*Nfields*Nstages*Nstages);
-
-  o_saab_x = platform.malloc<dfloat>(Nlevels*Nfields);
-  o_saab_a = platform.malloc<dfloat>(Nlevels*Nfields*Nstages*Nstages);
-  o_saab_b = platform.malloc<dfloat>(Nlevels*Nfields*Nstages*Nstages);
-
-  memory<dfloat> zeros(Nlevels*Nfields*Nstages*Nstages, 0.0);
-  o_zeros = platform.malloc<dfloat>(zeros);
-}
-
-void mrsaab3::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloat end) {
-
-  dfloat time = start;
-
-  //set timesteps and shifting index
-  for (int lev=0;lev<Nlevels;lev++) {
-    mrdt[lev] = dt*(1 << lev);
-    h_shiftIndex[lev] = 0;
-  }
-  o_mrdt.copyFrom(mrdt);
-  h_shiftIndex.copyTo(o_shiftIndex);
-
-  solver.Report(time,0);
-
-  dfloat outputInterval=0.0;
-  solver.settings.getSetting("OUTPUT INTERVAL", outputInterval);
-
-  dfloat outputTime = time + outputInterval;
-
-  //Compute coefficients
-  UpdateCoefficients(Nfields, lambda, Nlevels, dt, h_saab_x, h_saab_a, h_saab_b);
-
-  // move data to platform
-  h_saab_x.copyTo(o_saab_x, properties_t("async", true));
-  h_saab_a.copyTo(o_saab_a, properties_t("async", true));
-  h_saab_b.copyTo(o_saab_b, properties_t("async", true));
-
-  // Populate Trace Buffer
-  traceUpdateKernel(mesh.mrNelements[Nlevels-1],
-                    mesh.o_mrElements[Nlevels-1],
-                    mesh.o_mrLevel,
-                    mesh.o_vmapM,
-                    N,
-                    o_shiftIndex,
-                    o_mrdt,
-                    o_saab_x,
-                    o_zeros,
-                    o_rhsq0,
-                    o_rhsq,
-                    o_q,
-                    o_fQM);
-
-  dfloat DT = dt*(1 << (Nlevels-1));
-
-  int tstep=0;
-  int order=0;
-  while (time < end) {
-    Step(solver, o_q, time, dt, order);
-    time += DT;
-    tstep++;
-    if (order<Nstages-1) order++;
-
-    if (time>outputTime) {
-      //report state
-      solver.Report(outputTime,tstep);
-      outputTime += outputInterval;
-    }
-  }
-}
-
-void mrsaab3::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloat _dt, int order) {
-
-  deviceMemory<dfloat> o_A = o_saab_a+order*Nstages;
-  deviceMemory<dfloat> o_B = o_saab_b+order*Nstages;
-
-  for (int Ntick=0; Ntick < (1 << (Nlevels-1));Ntick++) {
-
-    // intermediate stage time
-    dfloat currentTime = time + dt*Ntick;
-
-    int lev=0;
-    for (;lev<Nlevels-1;lev++)
-      if (Ntick % (1<<(lev+1)) != 0) break; //find the max lev to compute rhs
-
-    //evaluate ODE rhs = f(q,t)
-    solver.rhsf_MR(o_q, o_rhsq0, o_fQM, currentTime, lev);
-
-    for (lev=0;lev<Nlevels-1;lev++)
-      if ((Ntick+1) % (1<<(lev+1)) !=0) break; //find the max lev to update
-
-    // update all elements of level <= lev
-    if (mesh.mrNelements[lev])
-      updateKernel(mesh.mrNelements[lev],
-                   mesh.o_mrElements[lev],
-                   mesh.o_mrLevel,
-                   mesh.o_vmapM,
-                   N,
-                   o_shiftIndex,
-                   o_mrdt,
-                   o_saab_x,
-                   o_A,
-                   o_rhsq0,
-                   o_rhsq,
-                   o_fQM,
-                   o_q);
-
-    //rotate index
-    if (Nstages>2)
-      for (int l=0; l<=lev; l++)
-        h_shiftIndex[l] = (h_shiftIndex[l]+Nstages-2)%(Nstages-1);
-
-    //compute intermediate trace values on lev+1 / lev interface
-    if (lev+1<Nlevels && mesh.mrInterfaceNelements[lev+1])
-      traceUpdateKernel(mesh.mrInterfaceNelements[lev+1],
-                        mesh.o_mrInterfaceElements[lev+1],
-                        mesh.o_mrLevel,
-                        mesh.o_vmapM,
-                        N,
-                        o_shiftIndex,
-                        o_mrdt,
-                        o_saab_x,
-                        o_B,
-                        o_rhsq0,
-                        o_rhsq,
-                        o_q,
-                        o_fQM);
-
-    h_shiftIndex.copyTo(o_shiftIndex, properties_t("async", true));
-  }
-}
-
-
-static void UpdateCoefficients(const int Nfields,
-                               const memory<dfloat> &lambda,
-                               const int Nlevels,
-                               const dfloat dt,
-                               pinnedMemory<dfloat> &saab_x,
-                               pinnedMemory<dfloat> &saab_a,
-                               pinnedMemory<dfloat> &saab_b) {
-
-  const int Nr = 32;
-  complex<dfloat> R[Nr];
-
-  //contour integral integration points
-  for(int ind=1; ind <= Nr; ++ind){
-    const dfloat theta = (dfloat) (ind - 0.5) / (dfloat) Nr;
-    complex<dfloat> z(0., M_PI* theta);
-    R[ind-1] = exp(z);
-  }
-
-  for(int lev=0; lev<Nlevels; ++lev){
-
-    for (int n=0;n<Nfields;n++) {
-
-      dfloat* X = saab_x.ptr() + n         + lev * Nfields;
-      dfloat* A = saab_a.ptr() + n * 3 * 3 + lev * Nfields * 3 * 3;
-      dfloat* B = saab_b.ptr() + n * 3 * 3 + lev * Nfields * 3 * 3;
-
-      if (lambda[n]==0) { //Zero exponential term, usual AB coefficients
-
-        X[0]  = 1.0;
-
-        A[0 + 0*3] =      1.; A[1 + 0*3] =       0.; A[2 + 0*3]=     0.;
-        A[0 + 1*3] =   3./2.; A[1 + 1*3] =   -1./2.; A[2 + 1*3]=     0.;
-        A[0 + 2*3] = 23./12.; A[1 + 2*3] = -16./12.; A[2 + 2*3]= 5./12.;
-
-        B[0 + 0*3] =   1./2.; B[1 + 0*3] =      0.; B[2 + 0*3]=     0.;
-        B[0 + 1*3] =   5./8.; B[1 + 1*3] =  -1./8.; B[2 + 1*3]=     0.;
-        B[0 + 2*3] = 17./24.; B[1 + 2*3] = -7./24.; B[2 + 2*3]= 2./24.;
-
-      } else {
-
-        //Compute coefficients via contour integral
-        dfloat alpha = lambda[n]*dt*(1<<lev);
-
-        // Initialize complex variables for contour integral
-        complex<double> a11(0.,0.);
-        complex<double> a21(0.,0.);
-        complex<double> a22(0.,0.);
-        complex<double> a31(0.,0.);
-        complex<double> a32(0.,0.);
-        complex<double> a33(0.,0.);
-
-        complex<double> b11(0.,0.);
-        complex<double> b21(0.,0.);
-        complex<double> b22(0.,0.);
-        complex<double> b31(0.,0.);
-        complex<double> b32(0.,0.);
-        complex<double> b33(0.,0.);
-
-        for(int i = 0; i<Nr; ++i ){
-          complex<double> lr = alpha  + R[i];
-
-          a11 +=  (exp(lr) - 1.)/lr;
-          b11 +=  (exp(lr/2.) - 1.)/lr;
-
-          a21 +=  (-2.*lr + (1.+lr)*exp(lr) - 1.)/pow(lr,2);
-          a22 +=  (lr - exp(lr) + 1.)/pow(lr,2);
-          b21 +=  (-1.5*lr + (1.+lr)*exp(lr/2.) - 1.)/pow(lr,2);
-          b22 +=  (0.5*lr - exp(lr/2.) + 1.)/pow(lr,2);
-
-          a31 += (-2.5*lr - 3.*pow(lr,2) + (1.+pow(lr,2)+1.5*lr)*exp(lr) - 1.)/pow(lr,3);
-          a32 += (4.*lr + 3.*pow(lr,2)- (2.*lr + 2.0)*exp(lr) + 2.)/pow(lr,3);
-          a33 +=-(1.5*lr + pow(lr,2)- (0.5*lr + 1.)*exp(lr) + 1.)/pow(lr,3);
-          b31 += (exp(lr/2.)- 2.*lr - (15.*pow(lr,2))/8. + (pow(lr,2) + 1.5*lr)*exp(lr/2.) - 1.)/pow(lr,3);
-          b32 += (3.*lr - 2.*exp(lr/2.0) + 1.25*pow(lr,2) - 2.*lr*exp(lr/2.) + 2.)/pow(lr,3);
-          b33 +=-(lr - exp(lr/2.) + 0.375*pow(lr,2) - 0.5*lr*exp(lr/2.) + 1.)/pow(lr,3);
-        }
-
-
-        dfloat aa11=real(a11)/ (double) Nr;
-        dfloat bb11=real(b11)/ (double) Nr;
-
-        dfloat aa21=real(a21)/ (double) Nr;
-        dfloat aa22=real(a22)/ (double) Nr;
-        dfloat bb21=real(b21)/ (double) Nr;
-        dfloat bb22=real(b22)/ (double) Nr;
-
-        dfloat aa31=real(a31)/ (double) Nr;
-        dfloat aa32=real(a32)/ (double) Nr;
-        dfloat aa33=real(a33)/ (double) Nr;
-
-        dfloat bb31=real(b31)/ (double) Nr;
-        dfloat bb32=real(b32)/ (double) Nr;
-        dfloat bb33=real(b33)/ (double) Nr;
-
-        X[0] = std::exp(alpha);
-
-        A[0 + 0*3] = aa11; A[1 + 0*3] =   0.; A[2 + 0*3]=   0.;
-        A[0 + 1*3] = aa21; A[1 + 1*3] = aa22; A[2 + 1*3]=   0.;
-        A[0 + 2*3] = aa31; A[1 + 2*3] = aa32; A[2 + 2*3]= aa33;
-
-        B[0 + 0*3] = bb11; B[1 + 0*3] =   0.; B[2 + 0*3]=   0.;
-        B[0 + 1*3] = bb21; B[1 + 1*3] = bb22; B[2 + 1*3]=   0.;
-        B[0 + 2*3] = bb31; B[1 + 2*3] = bb32; B[2 + 2*3]= bb33;
-      }
-    }
-  }
-}
-
-/**************************************************/
-/* PML version                                    */
-/**************************************************/
-
-mrsaab3_pml::mrsaab3_pml(dlong _Nelements, dlong NpmlElements, dlong _NhaloElements,
-                         int _Np, int _Nfields, int _Npmlfields,
-                         memory<dfloat> _lambda,
-                         platform_t& _platform, mesh_t& _mesh):
-  pmlTimeStepperBase_t(_Nelements, NpmlElements, _NhaloElements,
-                       _Np, _Nfields, _Npmlfields,
-                       _platform, _mesh.comm),
   mesh(_mesh),
   Nlevels(mesh.mrNlevels),
   Nfields(_Nfields),
@@ -425,10 +130,10 @@ mrsaab3_pml::mrsaab3_pml(dlong _Nelements, dlong NpmlElements, dlong _NhaloEleme
   o_zeros = platform.malloc<dfloat>(zeros);
 }
 
-void mrsaab3_pml::Run(solver_t& solver,
-                      deviceMemory<dfloat> &o_q,
-                      deviceMemory<dfloat> &o_pmlq,
-                      dfloat start, dfloat end) {
+void mrsaab3::Run(solver_t& solver,
+                  deviceMemory<dfloat> o_q,
+                  std::optional<deviceMemory<dfloat>> o_pmlq,
+                  dfloat start, dfloat end) {
 
   dfloat time = start;
 
@@ -448,12 +153,7 @@ void mrsaab3_pml::Run(solver_t& solver,
   dfloat outputTime = time + outputInterval;
 
   //Compute coefficients
-  UpdateCoefficients(Nfields, lambda, Nlevels, dt, h_saab_x, h_saab_a, h_saab_b);
-
-  // move data to platform
-  h_saab_x.copyTo(o_saab_x, properties_t("async", true));
-  h_saab_a.copyTo(o_saab_a, properties_t("async", true));
-  h_saab_b.copyTo(o_saab_b, properties_t("async", true));
+  UpdateCoefficients();
 
   // Populate Trace Buffer
   traceUpdateKernel(mesh.mrNelements[Nlevels-1],
@@ -488,16 +188,15 @@ void mrsaab3_pml::Run(solver_t& solver,
   }
 }
 
-void mrsaab3_pml::Step(solver_t& solver,
-                       deviceMemory<dfloat> &o_q,
-                       deviceMemory<dfloat> &o_pmlq,
-                       dfloat time, dfloat _dt, int order) {
+void mrsaab3::Step(solver_t& solver,
+                   deviceMemory<dfloat> o_q,
+                   std::optional<deviceMemory<dfloat>> o_pmlq,
+                   dfloat time, dfloat _dt, int order) {
 
   deviceMemory<dfloat> o_A = o_saab_a+order*Nstages;
   deviceMemory<dfloat> o_B = o_saab_b+order*Nstages;
 
-  deviceMemory<dfloat> o_pmlA;
-  if (Npml) o_pmlA = o_pmlsaab_a+order*Nstages;
+  deviceMemory<dfloat> o_pmlA = o_pmlsaab_a+order*Nstages;
 
   for (int Ntick=0; Ntick < (1 << (Nlevels-1));Ntick++) {
 
@@ -509,9 +208,13 @@ void mrsaab3_pml::Step(solver_t& solver,
       if (Ntick % (1<<(lev+1)) != 0) break; //find the max lev to compute rhs
 
     //evaluate ODE rhs = f(q,t)
-    solver.rhsf_MR_pml(o_q, o_pmlq,
-                       o_rhsq0, o_rhspmlq0,
-                       o_fQM, currentTime, lev);
+    if (o_pmlq.has_value()) {
+      solver.rhsf_MR_pml(o_q, o_pmlq.value(),
+                         o_rhsq0, o_rhspmlq0,
+                         o_fQM, currentTime, lev);
+    } else {
+      solver.rhsf_MR(o_q, o_rhsq0, o_fQM, currentTime, lev);
+    }
 
     for (lev=0;lev<Nlevels-1;lev++)
       if ((Ntick+1) % (1<<(lev+1)) !=0) break; //find the max lev to update
@@ -532,19 +235,21 @@ void mrsaab3_pml::Step(solver_t& solver,
                    o_fQM,
                    o_q);
 
-    if (mesh.mrNpmlElements[lev])
-      pmlUpdateKernel(mesh.mrNpmlElements[lev],
-                     mesh.o_mrPmlElements[lev],
-                     mesh.o_mrPmlIds[lev],
-                     mesh.o_mrLevel,
-                     Npml,
-                     Npmlfields,
-                     o_shiftIndex,
-                     o_mrdt,
-                     o_pmlA,
-                     o_rhspmlq0,
-                     o_rhspmlq,
-                     o_pmlq);
+    if (o_pmlq.has_value()) {
+      if (mesh.mrNpmlElements[lev])
+        pmlUpdateKernel(mesh.mrNpmlElements[lev],
+                       mesh.o_mrPmlElements[lev],
+                       mesh.o_mrPmlIds[lev],
+                       mesh.o_mrLevel,
+                       Npml,
+                       Npmlfields,
+                       o_shiftIndex,
+                       o_mrdt,
+                       o_pmlA,
+                       o_rhspmlq0,
+                       o_rhspmlq,
+                       o_pmlq.value());
+    }
 
     //rotate index
     if (Nstages>2)
@@ -570,6 +275,114 @@ void mrsaab3_pml::Step(solver_t& solver,
     h_shiftIndex.copyTo(o_shiftIndex, properties_t("async", true));
   }
 }
+
+void mrsaab3::UpdateCoefficients() {
+
+  const int Nr = 32;
+  complex<dfloat> R[Nr];
+
+  //contour integral integration points
+  for(int ind=1; ind <= Nr; ++ind){
+    const dfloat theta = (dfloat) (ind - 0.5) / (dfloat) Nr;
+    complex<dfloat> z(0., M_PI* theta);
+    R[ind-1] = exp(z);
+  }
+
+  for(int lev=0; lev<Nlevels; ++lev){
+
+    for (int n=0;n<Nfields;n++) {
+
+      dfloat* X = h_saab_x.ptr() + n         + lev * Nfields;
+      dfloat* A = h_saab_a.ptr() + n * 3 * 3 + lev * Nfields * 3 * 3;
+      dfloat* B = h_saab_b.ptr() + n * 3 * 3 + lev * Nfields * 3 * 3;
+
+      if (lambda[n]==0) { //Zero exponential term, usual AB coefficients
+
+        X[0]  = 1.0;
+
+        A[0 + 0*3] =      1.; A[1 + 0*3] =       0.; A[2 + 0*3]=     0.;
+        A[0 + 1*3] =   3./2.; A[1 + 1*3] =   -1./2.; A[2 + 1*3]=     0.;
+        A[0 + 2*3] = 23./12.; A[1 + 2*3] = -16./12.; A[2 + 2*3]= 5./12.;
+
+        B[0 + 0*3] =   1./2.; B[1 + 0*3] =      0.; B[2 + 0*3]=     0.;
+        B[0 + 1*3] =   5./8.; B[1 + 1*3] =  -1./8.; B[2 + 1*3]=     0.;
+        B[0 + 2*3] = 17./24.; B[1 + 2*3] = -7./24.; B[2 + 2*3]= 2./24.;
+
+      } else {
+
+        //Compute coefficients via contour integral
+        dfloat alpha = lambda[n]*dt*(1<<lev);
+
+        // Initialize complex variables for contour integral
+        complex<double> a11(0.,0.);
+        complex<double> a21(0.,0.);
+        complex<double> a22(0.,0.);
+        complex<double> a31(0.,0.);
+        complex<double> a32(0.,0.);
+        complex<double> a33(0.,0.);
+
+        complex<double> b11(0.,0.);
+        complex<double> b21(0.,0.);
+        complex<double> b22(0.,0.);
+        complex<double> b31(0.,0.);
+        complex<double> b32(0.,0.);
+        complex<double> b33(0.,0.);
+
+        for(int i = 0; i<Nr; ++i ){
+          complex<double> lr = alpha  + R[i];
+
+          a11 +=  (exp(lr) - 1.)/lr;
+          b11 +=  (exp(lr/2.) - 1.)/lr;
+
+          a21 +=  (-2.*lr + (1.+lr)*exp(lr) - 1.)/pow(lr,2);
+          a22 +=  (lr - exp(lr) + 1.)/pow(lr,2);
+          b21 +=  (-1.5*lr + (1.+lr)*exp(lr/2.) - 1.)/pow(lr,2);
+          b22 +=  (0.5*lr - exp(lr/2.) + 1.)/pow(lr,2);
+
+          a31 += (-2.5*lr - 3.*pow(lr,2) + (1.+pow(lr,2)+1.5*lr)*exp(lr) - 1.)/pow(lr,3);
+          a32 += (4.*lr + 3.*pow(lr,2)- (2.*lr + 2.0)*exp(lr) + 2.)/pow(lr,3);
+          a33 +=-(1.5*lr + pow(lr,2)- (0.5*lr + 1.)*exp(lr) + 1.)/pow(lr,3);
+          b31 += (exp(lr/2.)- 2.*lr - (15.*pow(lr,2))/8. + (pow(lr,2) + 1.5*lr)*exp(lr/2.) - 1.)/pow(lr,3);
+          b32 += (3.*lr - 2.*exp(lr/2.0) + 1.25*pow(lr,2) - 2.*lr*exp(lr/2.) + 2.)/pow(lr,3);
+          b33 +=-(lr - exp(lr/2.) + 0.375*pow(lr,2) - 0.5*lr*exp(lr/2.) + 1.)/pow(lr,3);
+        }
+
+
+        dfloat aa11=real(a11)/ (double) Nr;
+        dfloat bb11=real(b11)/ (double) Nr;
+
+        dfloat aa21=real(a21)/ (double) Nr;
+        dfloat aa22=real(a22)/ (double) Nr;
+        dfloat bb21=real(b21)/ (double) Nr;
+        dfloat bb22=real(b22)/ (double) Nr;
+
+        dfloat aa31=real(a31)/ (double) Nr;
+        dfloat aa32=real(a32)/ (double) Nr;
+        dfloat aa33=real(a33)/ (double) Nr;
+
+        dfloat bb31=real(b31)/ (double) Nr;
+        dfloat bb32=real(b32)/ (double) Nr;
+        dfloat bb33=real(b33)/ (double) Nr;
+
+        X[0] = std::exp(alpha);
+
+        A[0 + 0*3] = aa11; A[1 + 0*3] =   0.; A[2 + 0*3]=   0.;
+        A[0 + 1*3] = aa21; A[1 + 1*3] = aa22; A[2 + 1*3]=   0.;
+        A[0 + 2*3] = aa31; A[1 + 2*3] = aa32; A[2 + 2*3]= aa33;
+
+        B[0 + 0*3] = bb11; B[1 + 0*3] =   0.; B[2 + 0*3]=   0.;
+        B[0 + 1*3] = bb21; B[1 + 1*3] = bb22; B[2 + 1*3]=   0.;
+        B[0 + 2*3] = bb31; B[1 + 2*3] = bb32; B[2 + 2*3]= bb33;
+      }
+    }
+  }
+
+  // move data to platform
+  h_saab_x.copyTo(o_saab_x, properties_t("async", true));
+  h_saab_a.copyTo(o_saab_a, properties_t("async", true));
+  h_saab_b.copyTo(o_saab_b, properties_t("async", true));
+}
+
 
 } //namespace TimeStepper
 

--- a/libs/timeStepper/timeStepperMRSAAB3.cpp
+++ b/libs/timeStepper/timeStepperMRSAAB3.cpp
@@ -57,11 +57,8 @@ mrsaab3::mrsaab3(dlong _Nelements, dlong _NhaloElements,
 
   //Nstages = 3;
 
-  memory<dfloat> rhsq0(N, 0.0);
-  o_rhsq0 = platform.malloc<dfloat>(rhsq0);
-
-  memory<dfloat> rhsq((Nstages-1)*N, 0.0);
-  o_rhsq = platform.malloc<dfloat>(rhsq);
+  o_rhsq0 = platform.malloc<dfloat>(N);
+  o_rhsq = platform.malloc<dfloat>((Nstages-1)*N);
 
   o_fQM = platform.malloc<dfloat>((mesh.Nelements+mesh.totalHaloPairs)*mesh.Nfp
                                   *mesh.Nfaces*Nfields);
@@ -101,6 +98,9 @@ mrsaab3::mrsaab3(dlong _Nelements, dlong _NhaloElements,
   o_saab_x = platform.malloc<dfloat>(Nlevels*Nfields);
   o_saab_a = platform.malloc<dfloat>(Nlevels*Nfields*Nstages*Nstages);
   o_saab_b = platform.malloc<dfloat>(Nlevels*Nfields*Nstages*Nstages);
+
+  memory<dfloat> zeros(Nlevels*Nfields*Nstages*Nstages, 0.0);
+  o_zeros = platform.malloc<dfloat>(zeros);
 }
 
 void mrsaab3::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloat end) {
@@ -139,7 +139,7 @@ void mrsaab3::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfl
                     o_shiftIndex,
                     o_mrdt,
                     o_saab_x,
-                    o_saab_b,
+                    o_zeros,
                     o_rhsq0,
                     o_rhsq,
                     o_q,
@@ -354,17 +354,11 @@ mrsaab3_pml::mrsaab3_pml(dlong _Nelements, dlong NpmlElements, dlong _NhaloEleme
 
   //Nstages = 3;
 
-  memory<dfloat> rhsq0(N, 0.0);
-  o_rhsq0 = platform.malloc<dfloat>(rhsq0);
+  o_rhsq0 = platform.malloc<dfloat>(N);
+  o_rhsq = platform.malloc<dfloat>((Nstages-1)*N);
 
-  memory<dfloat> rhsq((Nstages-1)*N, 0.0);
-  o_rhsq = platform.malloc<dfloat>(rhsq);
-
-  memory<dfloat> rhspmlq0(Npml, 0.0);
-  o_rhspmlq0 = platform.malloc<dfloat>(rhspmlq0);
-
-  memory<dfloat> rhspmlq((Nstages-1)*Npml, 0.0);
-  o_rhspmlq = platform.malloc<dfloat>(rhspmlq);
+  o_rhspmlq0 = platform.malloc<dfloat>(Npml);
+  o_rhspmlq = platform.malloc<dfloat>((Nstages-1)*Npml);
 
   o_fQM = platform.malloc<dfloat>((mesh.Nelements+mesh.totalHaloPairs)*mesh.Nfp
                                   *mesh.Nfaces*Nfields);
@@ -426,6 +420,9 @@ mrsaab3_pml::mrsaab3_pml(dlong _Nelements, dlong NpmlElements, dlong _NhaloEleme
 
   o_pmlsaab_a = platform.malloc<dfloat>(pmlsaab_a);
   o_pmlsaab_b = platform.malloc<dfloat>(pmlsaab_b);
+
+  memory<dfloat> zeros(Nlevels*Nfields*Nstages*Nstages, 0.0);
+  o_zeros = platform.malloc<dfloat>(zeros);
 }
 
 void mrsaab3_pml::Run(solver_t& solver,
@@ -467,7 +464,7 @@ void mrsaab3_pml::Run(solver_t& solver,
                     o_shiftIndex,
                     o_mrdt,
                     o_saab_x,
-                    o_saab_b,
+                    o_zeros,
                     o_rhsq0,
                     o_rhsq,
                     o_q,

--- a/libs/timeStepper/timeStepperSAAB3.cpp
+++ b/libs/timeStepper/timeStepperSAAB3.cpp
@@ -95,8 +95,8 @@ void saab3::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
   UpdateCoefficients(Nfields, lambda, dt, h_saab_x, h_saab_a);
 
   // move data to platform
-  h_saab_x.copyTo(o_saab_x);
-  h_saab_a.copyTo(o_saab_a);
+  h_saab_x.copyTo(o_saab_x, properties_t("async", true));
+  h_saab_a.copyTo(o_saab_a, properties_t("async", true));
 
   int tstep=0;
   int order=0;
@@ -290,8 +290,8 @@ void saab3_pml::Run(solver_t& solver,
   UpdateCoefficients(Nfields, lambda, dt, h_saab_x, h_saab_a);
 
   // move data to platform
-  h_saab_x.copyTo(o_saab_x);
-  h_saab_a.copyTo(o_saab_a);
+  h_saab_x.copyTo(o_saab_x, properties_t("async", true));
+  h_saab_a.copyTo(o_saab_a, properties_t("async", true));
 
   int tstep=0;
   int order=0;

--- a/libs/timeStepper/timeStepperSARK4.cpp
+++ b/libs/timeStepper/timeStepperSARK4.cpp
@@ -35,6 +35,13 @@ namespace TimeStepper {
 
 using std::complex;
 
+static void UpdateCoefficients(const int Nfields,
+                               const memory<dfloat> &lambda,
+                               const dfloat dt,
+                               pinnedMemory<dfloat> &h_rkX,
+                               pinnedMemory<dfloat> &h_rkA,
+                               pinnedMemory<dfloat> &h_rkE);
+
 sark4::sark4(dlong _Nelements, dlong _NhaloElements,
              int _Np, int _Nfields,
              memory<dfloat> _lambda,
@@ -142,7 +149,15 @@ void sark4::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
   int tstep=0, allStep=0;
 
   //Compute Butcher Tableau
-  UpdateCoefficients();
+  UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
+
+  // move data to platform
+  // o_rkX.copyFrom(rkX, properties_t("async", true));
+  // o_rkA.copyFrom(rkA, properties_t("async", true));
+  // o_rkE.copyFrom(rkE, properties_t("async", true));
+  h_rkX.copyTo(o_rkX);
+  h_rkA.copyTo(o_rkA);
+  h_rkE.copyTo(o_rkE);
 
   while (time < end) {
 
@@ -184,7 +199,15 @@ void sark4::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
         //   printf("Taking output mini step: %g\n", dt);
 
         //Compute Butcher Tableau
-        UpdateCoefficients();
+        UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
+
+        // move data to platform
+        // o_rkX.copyFrom(rkX, properties_t("async", true));
+        // o_rkA.copyFrom(rkA, properties_t("async", true));
+        // o_rkE.copyFrom(rkE, properties_t("async", true));
+        h_rkX.copyTo(o_rkX);
+        h_rkA.copyTo(o_rkA);
+        h_rkE.copyTo(o_rkE);
 
         // time step to output
         Step(solver, o_q, time, dt);
@@ -232,7 +255,15 @@ void sark4::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
     dt = dtnew;
 
     //Compute Butcher Tableau
-    UpdateCoefficients();
+    UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
+
+    // move data to platform
+    // o_rkX.copyFrom(rkX, properties_t("async", true));
+    // o_rkA.copyFrom(rkA, properties_t("async", true));
+    // o_rkE.copyFrom(rkE, properties_t("async", true));
+    h_rkX.copyTo(o_rkX);
+    h_rkA.copyTo(o_rkA);
+    h_rkE.copyTo(o_rkE);
 
     allStep++;
   }
@@ -241,12 +272,12 @@ void sark4::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
     printf("%d accepted steps and %d total steps\n", tstep, allStep);
 }
 
-void sark4::Backup(deviceMemory<dfloat> &o_Q) {
-  o_saveq.copyFrom(o_Q, N);
+void sark4::Backup(deviceMemory<dfloat> &o_q) {
+  o_saveq.copyFrom(o_q, N);
 }
 
-void sark4::Restore(deviceMemory<dfloat> &o_Q) {
-  o_saveq.copyTo(o_Q, N);
+void sark4::Restore(deviceMemory<dfloat> &o_q) {
+  o_saveq.copyTo(o_q, N);
 }
 
 void sark4::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq) {
@@ -319,8 +350,14 @@ dfloat sark4::Estimater(deviceMemory<dfloat>& o_q){
   return err;
 }
 
-void sark4::UpdateCoefficients() {
+static void UpdateCoefficients(const int Nfields,
+                               const memory<dfloat> &lambda,
+                               const dfloat dt,
+                               pinnedMemory<dfloat> &h_rkX,
+                               pinnedMemory<dfloat> &h_rkA,
+                               pinnedMemory<dfloat> &h_rkE) {
 
+  constexpr int Nrk = 5;
   const int Nr = 32;
   complex<dfloat> R[Nr];
 
@@ -333,20 +370,21 @@ void sark4::UpdateCoefficients() {
 
   for (int n=0;n<Nfields;n++) {
 
+    dfloat* rkX = h_rkX.ptr() + n * Nrk;
+    dfloat* rkA = h_rkA.ptr() + n * Nrk * Nrk;
+    dfloat* rkE = h_rkE.ptr() + n * Nrk;
+
     if (lambda[n]==0) { //Zero exponential term, usual RK coefficients
 
-      dfloat _rkX[Nrk]  = {1.0, 1.0, 1.0, 1.0, 1.0 };
-      dfloat _rkA[Nrk*Nrk]
-                    = {      0.0,      0.0,       0.0,      0.0,       0.0,
-                             0.5,      0.0,       0.0,      0.0,       0.0,
-                             0.0,      0.5,       0.0,      0.0,       0.0,
-                             0.0,      0.0,       1.0,      0.0,       0.0,
-                         1.0/6.0,  1.0/3.0,   1.0/3.0,   1.0/6.0,      0.0};
-      dfloat _rkE[Nrk]= {    0.0,      0.0,       0.0,  -1.0/6.0,  1.0/6.0};
+      rkX[0] = 1.0; rkX[1] = 1.0; rkX[2] = 1.0; rkX[3] = 1.0; rkX[4] = 1.0;
 
-      h_rkX.copyFrom(_rkX,    Nrk,n*Nrk    );
-      h_rkA.copyFrom(_rkA,Nrk*Nrk,n*Nrk*Nrk);
-      h_rkE.copyFrom(_rkE,    Nrk,n*Nrk    );
+      rkA[0+0*Nrk] =     0.0; rkA[1+0*Nrk] =     0.0; rkA[2+0*Nrk] =     0.0; rkA[3+0*Nrk] =     0.0; rkA[4+0*Nrk] = 0.0;
+      rkA[0+1*Nrk] =     0.5; rkA[1+1*Nrk] =     0.0; rkA[2+1*Nrk] =     0.0; rkA[3+1*Nrk] =     0.0; rkA[4+1*Nrk] = 0.0;
+      rkA[0+2*Nrk] =     0.0; rkA[1+2*Nrk] =     0.5; rkA[2+2*Nrk] =     0.0; rkA[3+2*Nrk] =     0.0; rkA[4+2*Nrk] = 0.0;
+      rkA[0+3*Nrk] =     0.0; rkA[1+3*Nrk] =     0.0; rkA[2+3*Nrk] =     1.0; rkA[3+3*Nrk] =     0.0; rkA[4+3*Nrk] = 0.0;
+      rkA[0+4*Nrk] = 1.0/6.0; rkA[1+4*Nrk] = 1.0/3.0; rkA[2+4*Nrk] = 1.0/3.0; rkA[3+4*Nrk] = 1.0/6.0; rkA[4+4*Nrk] = 0.0;
+
+      rkE[0] = 0.0; rkE[1] = 0.0; rkE[2] = 0.0; rkE[3] = -1.0/6.0; rkE[4] = 1.0/6.0;
 
     } else {
 
@@ -396,31 +434,16 @@ void sark4::UpdateCoefficients() {
       dfloat a54=real(ca54)/ (double) Nr;
 
       // first set non-semianalytic part of the integrator
-      dfloat _rkX[Nrk]  = {1.0,
-                           std::exp(dfloat(0.5)*alpha),
-                           std::exp(dfloat(0.5)*alpha),
-                           std::exp(alpha),
-                           std::exp(alpha) };
-      dfloat _rkA[Nrk*Nrk]
-                      ={   0.0,  0.0,  0.0,   0.0,  0.0,
-                           a21,  0.0,  0.0,   0.0,  0.0,
-                           a31,  a32,  0.0,   0.0,  0.0,
-                           a41,  0.0,  a43,   0.0,  0.0,
-                           a51,  a52,  a53,   a54,  0.0};
-      dfloat _rkE[Nrk]= {  0.0,  0.0,  0.0,  -a54,  a54};
+      rkX[0] = 1.0; rkX[1] = std::exp(dfloat(0.5)*alpha); rkX[2] = std::exp(dfloat(0.5)*alpha); rkX[3] = std::exp(alpha); rkX[4] = std::exp(alpha);
 
-      h_rkX.copyFrom(_rkX,    Nrk,n*Nrk    );
-      h_rkA.copyFrom(_rkA,Nrk*Nrk,n*Nrk*Nrk);
-      h_rkE.copyFrom(_rkE,    Nrk,n*Nrk    );
+      rkA[0+0*Nrk] = 0.0; rkA[1+0*Nrk] = 0.0; rkA[2+0*Nrk] = 0.0; rkA[3+0*Nrk] = 0.0; rkA[4+0*Nrk] = 0.0;
+      rkA[0+1*Nrk] = a21; rkA[1+1*Nrk] = 0.0; rkA[2+1*Nrk] = 0.0; rkA[3+1*Nrk] = 0.0; rkA[4+1*Nrk] = 0.0;
+      rkA[0+2*Nrk] = a31; rkA[1+2*Nrk] = a32; rkA[2+2*Nrk] = 0.0; rkA[3+2*Nrk] = 0.0; rkA[4+2*Nrk] = 0.0;
+      rkA[0+3*Nrk] = a41; rkA[1+3*Nrk] = 0.0; rkA[2+3*Nrk] = a43; rkA[3+3*Nrk] = 0.0; rkA[4+3*Nrk] = 0.0;
+      rkA[0+4*Nrk] = a51; rkA[1+4*Nrk] = a52; rkA[2+4*Nrk] = a53; rkA[3+4*Nrk] = a54; rkA[4+4*Nrk] = 0.0;
+
+      rkE[0] = 0.0; rkE[1] = 0.0; rkE[2] = 0.0; rkE[3] = -a54; rkE[4] = a54;
     }
-
-    // move data to platform
-    // o_rkX.copyFrom(rkX, properties_t("async", true));
-    // o_rkA.copyFrom(rkA, properties_t("async", true));
-    // o_rkE.copyFrom(rkE, properties_t("async", true));
-    h_rkX.copyTo(o_rkX);
-    h_rkA.copyTo(o_rkA);
-    h_rkE.copyTo(o_rkE);
   }
 }
 
@@ -429,78 +452,283 @@ void sark4::UpdateCoefficients() {
 /* PML version                                    */
 /**************************************************/
 
-sark4_pml::sark4_pml(dlong _Nelements, dlong _NpmlElements, dlong _NhaloElements,
-            int _Np, int _Nfields, int _Npmlfields,
-            memory<dfloat> _lambda,
-            platform_t& _platform, comm_t _comm):
-  sark4(_Nelements, _NhaloElements, _Np, _Nfields, _lambda, _platform, _comm),
-  Npml(_Npmlfields*_Np*_NpmlElements) {
+sark4_pml::sark4_pml(dlong _Nelements, dlong NpmlElements, dlong _NhaloElements,
+                     int _Np, int _Nfields, int _Npmlfields,
+                     memory<dfloat> _lambda,
+                     platform_t& _platform, comm_t _comm):
+  pmlTimeStepperBase_t(_Nelements, NpmlElements, _NhaloElements,
+                       _Np, _Nfields, _Npmlfields,
+                       _platform, _comm),
+  Np(_Np),
+  Nfields(_Nfields),
+  Nelements(_Nelements),
+  NhaloElements(_NhaloElements) {
 
-  if (Npml) {
-    memory<dfloat> pmlq(Npml,0.0);
-    o_pmlq = platform.malloc<dfloat>(pmlq);
+  lambda.malloc(Nfields);
+  lambda.copyFrom(_lambda);
 
-    o_rkpmlq    = platform.malloc<dfloat>(Npml);
-    o_rhspmlq   = platform.malloc<dfloat>(Npml);
-    o_rkrhspmlq = platform.malloc<dfloat>(Npml*Nrk);
+  //Nrk = 5;
+  order = 4;
+  embeddedOrder = 3;
 
-    o_savepmlq   = platform.malloc<dfloat>(Npml);
+  dlong Nlocal = Nelements*Np*Nfields;
+  dlong Ntotal = (Nelements+NhaloElements)*Np*Nfields;
 
-    //copy base occa properties from solver
-    properties_t kernelInfo = platform.props();
+  o_rkq    = platform.malloc<dfloat>(Ntotal);
+  o_rhsq   = platform.malloc<dfloat>(Nlocal);
+  o_rkrhsq = platform.malloc<dfloat>(Nlocal*Nrk);
+  o_rkpmlq    = platform.malloc<dfloat>(Npml);
+  o_rhspmlq   = platform.malloc<dfloat>(Npml);
+  o_rkrhspmlq = platform.malloc<dfloat>(Npml*Nrk);
 
-    const int blocksize=256;
+  o_rkerr  = platform.malloc<dfloat>(Nlocal);
 
-    //add defines
-    kernelInfo["defines/" "p_blockSize"] = (int)blocksize;
-    kernelInfo["defines/" "p_Nrk"]     = (int)Nrk;
-    kernelInfo["defines/" "p_Np"]      = (int)Np;
-    kernelInfo["defines/" "p_Nfields"] = (int)Nfields;
+  o_saveq  = platform.malloc<dfloat>(Nlocal);
+  o_savepmlq   = platform.malloc<dfloat>(Npml);
 
-    rkPmlUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+  const int blocksize=256;
+
+  Nblock = (N+blocksize-1)/blocksize;
+  h_errtmp = platform.hostMalloc<dfloat>(Nblock);
+  o_errtmp = platform.malloc<dfloat>(Nblock);
+
+  hlong gNtotal = Nlocal;
+  comm.Allreduce(gNtotal);
+
+  //copy base occa properties from platform
+  properties_t kernelInfo = platform.props();
+
+  //add defines
+  kernelInfo["defines/" "p_blockSize"] = (int)blocksize;
+  kernelInfo["defines/" "p_Nrk"]     = (int)Nrk;
+  kernelInfo["defines/" "p_Np"]      = (int)Np;
+  kernelInfo["defines/" "p_Nfields"] = (int)Nfields;
+
+  rkUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+                                    "timeStepperSARK.okl",
+                                    "sarkRkUpdate",
+                                    kernelInfo);
+  rkPmlUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
                                       "timeStepperSARK.okl",
                                       "sarkRkPmlUpdate",
                                       kernelInfo);
-
-    rkPmlStageKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+  rkStageKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+                                    "timeStepperSARK.okl",
+                                    "sarkRkStage",
+                                    kernelInfo);
+  rkPmlStageKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
                                       "timeStepperSARK.okl",
                                       "sarkRkPmlStage",
                                       kernelInfo);
+  rkErrorEstimateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+                                    "timeStepperSARK.okl",
+                                    "sarkErrorEstimate",
+                                    kernelInfo);
 
-    // Semi-Analytic Runge Kutta - order (3) 4 with PID timestep control
-    pmlrkA.malloc(Nrk*Nrk);
+  // Semi-Analytic Runge Kutta - order (3) 4 with PID timestep control
+  dfloat _rkC[Nrk] = {0.0, 0.5, 0.5, 1.0, 1.0};
+  rkC.malloc(Nrk);
+  rkC.copyFrom(_rkC);
 
-    dfloat _pmlrkA[Nrk*Nrk]
-                    = {      0.0,      0.0,       0.0,      0.0,       0.0,
-                             0.5,      0.0,       0.0,      0.0,       0.0,
-                             0.0,      0.5,       0.0,      0.0,       0.0,
-                             0.0,      0.0,       1.0,      0.0,       0.0,
-                         1.0/6.0,  1.0/3.0,   1.0/3.0,   1.0/6.0,      0.0};
-    pmlrkA.copyFrom(_pmlrkA);
+  h_rkX = platform.hostMalloc<dfloat>(Nfields*Nrk);
+  h_rkA = platform.hostMalloc<dfloat>(Nfields*Nrk*Nrk);
+  h_rkE = platform.hostMalloc<dfloat>(Nfields*Nrk);
 
-    o_pmlrkA = platform.malloc<dfloat>(pmlrkA);
+  o_rkX = platform.malloc<dfloat>(Nfields*Nrk);
+  o_rkA = platform.malloc<dfloat>(Nfields*Nrk*Nrk);
+  o_rkE = platform.malloc<dfloat>(Nfields*Nrk);
+
+  pmlrkA.malloc(Nrk*Nrk);
+
+  dfloat _pmlrkA[Nrk*Nrk]
+                  = {      0.0,      0.0,       0.0,      0.0,       0.0,
+                           0.5,      0.0,       0.0,      0.0,       0.0,
+                           0.0,      0.5,       0.0,      0.0,       0.0,
+                           0.0,      0.0,       1.0,      0.0,       0.0,
+                       1.0/6.0,  1.0/3.0,   1.0/3.0,   1.0/6.0,      0.0};
+  pmlrkA.copyFrom(_pmlrkA);
+
+  o_pmlrkA = platform.malloc<dfloat>(pmlrkA);
+
+  dtMIN = 1E-9; //minumum allowed timestep
+  ATOL = 1E-5;  //absolute error tolerance
+  RTOL = 1E-4;  //relative error tolerance
+  safe = 0.8;   //safety factor
+
+  //error control parameters
+  beta = 0.05;
+  factor1 = 0.2;
+  factor2 = 10.0;
+
+  exp1 = 1.0/(embeddedOrder+1) - 0.75*beta;
+  invfactor1 = 1.0/factor1;
+  invfactor2 = 1.0/factor2;
+  facold = 1E-4;
+  sqrtinvNtotal = 1.0/sqrt(gNtotal);
+}
+
+void sark4_pml::Run(solver_t& solver,
+                    deviceMemory<dfloat> &o_q,
+                    deviceMemory<dfloat> &o_pmlq,
+                    dfloat start, dfloat end) {
+
+  dfloat time = start;
+
+  int rank = comm.rank();
+
+  solver.Report(time,0);
+
+  dfloat outputInterval=0.0;
+  solver.settings.getSetting("OUTPUT INTERVAL", outputInterval);
+
+  dfloat outputTime = time + outputInterval;
+
+  int tstep=0, allStep=0;
+
+  //Compute Butcher Tableau
+  UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
+
+  // move data to platform
+  // o_rkX.copyFrom(rkX, properties_t("async", true));
+  // o_rkA.copyFrom(rkA, properties_t("async", true));
+  // o_rkE.copyFrom(rkE, properties_t("async", true));
+  h_rkX.copyTo(o_rkX);
+  h_rkA.copyTo(o_rkA);
+  h_rkE.copyTo(o_rkE);
+
+  while (time < end) {
+
+    LIBP_ABORT("Time step became too small at time step = " << tstep,
+               dt<dtMIN);
+    LIBP_ABORT("Solution became unstable at time step = " << tstep,
+               std::isnan(dt));
+
+    //check for final timestep
+    if (time+dt > end){
+      dt = end-time;
+    }
+
+    Step(solver, o_q, o_pmlq, time, dt);
+
+    // compute Dopri estimator
+    dfloat err = Estimater(o_q);
+
+    // build controller
+    dfloat fac1 = pow(err,exp1);
+    dfloat fac = fac1/pow(facold,beta);
+
+    fac = std::max(invfactor2, std::min(invfactor1,fac/safe));
+    dfloat dtnew = dt/fac;
+
+    if (err<1.0) { //dt is accepted
+
+      // check for output during this step and do a mini-step
+      if (time<outputTime && time+dt>=outputTime) {
+        dfloat savedt = dt;
+
+        // save rkq
+        Backup(o_rkq, o_rkpmlq);
+
+        // change dt to match output
+        dt = outputTime-time;
+
+        // if(!rank)
+        //   printf("Taking output mini step: %g\n", dt);
+
+        //Compute Butcher Tableau
+        UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
+
+        // move data to platform
+        // o_rkX.copyFrom(rkX, properties_t("async", true));
+        // o_rkA.copyFrom(rkA, properties_t("async", true));
+        // o_rkE.copyFrom(rkE, properties_t("async", true));
+        h_rkX.copyTo(o_rkX);
+        h_rkA.copyTo(o_rkA);
+        h_rkE.copyTo(o_rkE);
+
+        // time step to output
+        Step(solver, o_q, o_pmlq, time, dt);
+
+        // shift for output
+        o_rkq.copyTo(o_q);
+
+        // output  (print from rkq)
+        // if (!rank) printf("\n");
+        solver.Report(outputTime,tstep);
+
+        // restore time step
+        dt = savedt;
+
+        // increment next output time
+        outputTime += outputInterval;
+
+        // accept saved rkq
+        Restore(o_rkq, o_rkpmlq);
+        AcceptStep(o_q, o_rkq, o_pmlq, o_rkpmlq);
+
+      } else {
+        // accept rkq
+        AcceptStep(o_q, o_rkq, o_pmlq, o_rkpmlq);
+      }
+
+      time += dt;
+      while (time>outputTime) outputTime+= outputInterval; //catch up next output in case dt>outputInterval
+
+      constexpr dfloat errMax = 1.0e-4;  // hard coded factor ?
+      facold = std::max(err,errMax);
+
+      // if (!rank)
+      //   printf("\r time = %g (%d), dt = %g accepted                      ", time, allStep,  dt);
+
+      tstep++;
+    } else {
+      dtnew = dt/(std::max(invfactor1,fac1/safe));
+
+      // if (!rank)
+      //   printf("\r time = %g (%d), dt = %g rejected, trying %g", time, allStep, dt, dtnew);
+      if (!rank)
+        printf("Repeating timestep %d. dt was %g, trying %g.\n", tstep, dt, dtnew);
+    }
+    dt = dtnew;
+
+    //Compute Butcher Tableau
+    UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
+
+    // move data to platform
+    // o_rkX.copyFrom(rkX, properties_t("async", true));
+    // o_rkA.copyFrom(rkA, properties_t("async", true));
+    // o_rkE.copyFrom(rkE, properties_t("async", true));
+    h_rkX.copyTo(o_rkX);
+    h_rkA.copyTo(o_rkA);
+    h_rkE.copyTo(o_rkE);
+
+    allStep++;
   }
+
+  if (!rank)
+    printf("%d accepted steps and %d total steps\n", tstep, allStep);
 }
 
-void sark4_pml::Backup(deviceMemory<dfloat> &o_Q) {
-  o_saveq.copyFrom(o_Q, N);
-  if (Npml)
-    o_savepmlq.copyFrom(o_rkpmlq, Npml);
+void sark4_pml::Backup(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq) {
+  o_saveq.copyFrom(o_q, N);
+  o_savepmlq.copyFrom(o_rkpmlq, Npml);
 }
 
-void sark4_pml::Restore(deviceMemory<dfloat> &o_Q) {
-  o_saveq.copyTo(o_Q, N);
-  if (Npml)
-    o_savepmlq.copyTo(o_rkpmlq, Npml);
+void sark4_pml::Restore(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq) {
+  o_saveq.copyTo(o_q, N);
+  o_savepmlq.copyTo(o_rkpmlq, Npml);
 }
 
-void sark4_pml::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq) {
+void sark4_pml::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq,
+                           deviceMemory<dfloat> &o_pmlq, deviceMemory<dfloat> &o_rpmlq) {
   o_q.copyFrom(o_rq, N);
-  if (Npml)
-    o_pmlq.copyFrom(o_rkpmlq, Npml);
+  o_pmlq.copyFrom(o_rpmlq, Npml);
 }
 
-void sark4_pml::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloat _dt) {
+void sark4_pml::Step(solver_t& solver,
+                     deviceMemory<dfloat> &o_q,
+                     deviceMemory<dfloat> &o_pmlq,
+                     dfloat time, dfloat _dt) {
 
   //RK step
   for(int rk=0;rk<Nrk;++rk){
@@ -518,7 +746,6 @@ void sark4_pml::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, d
                   o_q,
                   o_rkrhsq,
                   o_rkq);
-
     if (Npml)
       rkPmlStageKernel(Npml,
                       rk,
@@ -557,6 +784,31 @@ void sark4_pml::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, d
                          o_rkrhspmlq,
                          o_rkpmlq);
   }
+}
+
+dfloat sark4_pml::Estimater(deviceMemory<dfloat>& o_q){
+
+  //Error estimation
+  //E. HAIRER, S.P. NORSETT AND G. WANNER, SOLVING ORDINARY
+  //      DIFFERENTIAL EQUATIONS I. NONSTIFF PROBLEMS. 2ND EDITION.
+  rkErrorEstimateKernel(Nelements*Np*Nfields,
+                        ATOL,
+                        RTOL,
+                        o_q,
+                        o_rkq,
+                        o_rkerr,
+                        o_errtmp);
+
+  h_errtmp.copyFrom(o_errtmp);
+  dfloat err = 0;
+  for(dlong n=0;n<Nblock;++n){
+    err += h_errtmp[n];
+  }
+  comm.Allreduce(err);
+
+  err = sqrt(err)*sqrtinvNtotal;
+
+  return err;
 }
 
 } //namespace TimeStepper

--- a/libs/timeStepper/timeStepperSARK4.cpp
+++ b/libs/timeStepper/timeStepperSARK4.cpp
@@ -137,8 +137,6 @@ void sark4::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
 
   dfloat time = start;
 
-  int rank = comm.rank();
-
   solver.Report(time,0);
 
   dfloat outputInterval=0.0;
@@ -152,12 +150,9 @@ void sark4::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
   UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
 
   // move data to platform
-  // o_rkX.copyFrom(rkX, properties_t("async", true));
-  // o_rkA.copyFrom(rkA, properties_t("async", true));
-  // o_rkE.copyFrom(rkE, properties_t("async", true));
-  h_rkX.copyTo(o_rkX);
-  h_rkA.copyTo(o_rkA);
-  h_rkE.copyTo(o_rkE);
+  h_rkX.copyTo(o_rkX, properties_t("async", true));
+  h_rkA.copyTo(o_rkA, properties_t("async", true));
+  h_rkE.copyTo(o_rkE, properties_t("async", true));
 
   while (time < end) {
 
@@ -195,28 +190,21 @@ void sark4::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
         // change dt to match output
         dt = outputTime-time;
 
-        // if(!rank)
-        //   printf("Taking output mini step: %g\n", dt);
-
         //Compute Butcher Tableau
         UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
 
         // move data to platform
-        // o_rkX.copyFrom(rkX, properties_t("async", true));
-        // o_rkA.copyFrom(rkA, properties_t("async", true));
-        // o_rkE.copyFrom(rkE, properties_t("async", true));
-        h_rkX.copyTo(o_rkX);
-        h_rkA.copyTo(o_rkA);
-        h_rkE.copyTo(o_rkE);
+        h_rkX.copyTo(o_rkX, properties_t("async", true));
+        h_rkA.copyTo(o_rkA, properties_t("async", true));
+        h_rkE.copyTo(o_rkE, properties_t("async", true));
 
         // time step to output
         Step(solver, o_q, time, dt);
 
         // shift for output
-        o_rkq.copyTo(o_q);
+        o_rkq.copyTo(o_q, properties_t("async", true));
 
         // output  (print from rkq)
-        // if (!rank) printf("\n");
         solver.Report(outputTime,tstep);
 
         // restore time step
@@ -240,17 +228,9 @@ void sark4::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
       constexpr dfloat errMax = 1.0e-4;  // hard coded factor ?
       facold = std::max(err,errMax);
 
-      // if (!rank)
-      //   printf("\r time = %g (%d), dt = %g accepted                      ", time, allStep,  dt);
-
       tstep++;
     } else {
       dtnew = dt/(std::max(invfactor1,fac1/safe));
-
-      // if (!rank)
-      //   printf("\r time = %g (%d), dt = %g rejected, trying %g", time, allStep, dt, dtnew);
-      if (!rank)
-        printf("Repeating timestep %d. dt was %g, trying %g.\n", tstep, dt, dtnew);
     }
     dt = dtnew;
 
@@ -258,30 +238,24 @@ void sark4::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
     UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
 
     // move data to platform
-    // o_rkX.copyFrom(rkX, properties_t("async", true));
-    // o_rkA.copyFrom(rkA, properties_t("async", true));
-    // o_rkE.copyFrom(rkE, properties_t("async", true));
-    h_rkX.copyTo(o_rkX);
-    h_rkA.copyTo(o_rkA);
-    h_rkE.copyTo(o_rkE);
+    h_rkX.copyTo(o_rkX, properties_t("async", true));
+    h_rkA.copyTo(o_rkA, properties_t("async", true));
+    h_rkE.copyTo(o_rkE, properties_t("async", true));
 
     allStep++;
   }
-
-  if (!rank)
-    printf("%d accepted steps and %d total steps\n", tstep, allStep);
 }
 
 void sark4::Backup(deviceMemory<dfloat> &o_q) {
-  o_saveq.copyFrom(o_q, N);
+  o_saveq.copyFrom(o_q, N, properties_t("async", true));
 }
 
 void sark4::Restore(deviceMemory<dfloat> &o_q) {
-  o_saveq.copyTo(o_q, N);
+  o_saveq.copyTo(o_q, N, properties_t("async", true));
 }
 
 void sark4::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq) {
-  o_q.copyFrom(o_rq, N);
+  o_q.copyFrom(o_rq, N, properties_t("async", true));
 }
 
 void sark4::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloat _dt) {
@@ -574,8 +548,6 @@ void sark4_pml::Run(solver_t& solver,
 
   dfloat time = start;
 
-  int rank = comm.rank();
-
   solver.Report(time,0);
 
   dfloat outputInterval=0.0;
@@ -589,12 +561,9 @@ void sark4_pml::Run(solver_t& solver,
   UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
 
   // move data to platform
-  // o_rkX.copyFrom(rkX, properties_t("async", true));
-  // o_rkA.copyFrom(rkA, properties_t("async", true));
-  // o_rkE.copyFrom(rkE, properties_t("async", true));
-  h_rkX.copyTo(o_rkX);
-  h_rkA.copyTo(o_rkA);
-  h_rkE.copyTo(o_rkE);
+  h_rkX.copyTo(o_rkX, properties_t("async", true));
+  h_rkA.copyTo(o_rkA, properties_t("async", true));
+  h_rkE.copyTo(o_rkE, properties_t("async", true));
 
   while (time < end) {
 
@@ -632,28 +601,21 @@ void sark4_pml::Run(solver_t& solver,
         // change dt to match output
         dt = outputTime-time;
 
-        // if(!rank)
-        //   printf("Taking output mini step: %g\n", dt);
-
         //Compute Butcher Tableau
         UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
 
         // move data to platform
-        // o_rkX.copyFrom(rkX, properties_t("async", true));
-        // o_rkA.copyFrom(rkA, properties_t("async", true));
-        // o_rkE.copyFrom(rkE, properties_t("async", true));
-        h_rkX.copyTo(o_rkX);
-        h_rkA.copyTo(o_rkA);
-        h_rkE.copyTo(o_rkE);
+        h_rkX.copyTo(o_rkX, properties_t("async", true));
+        h_rkA.copyTo(o_rkA, properties_t("async", true));
+        h_rkE.copyTo(o_rkE, properties_t("async", true));
 
         // time step to output
         Step(solver, o_q, o_pmlq, time, dt);
 
         // shift for output
-        o_rkq.copyTo(o_q);
+        o_rkq.copyTo(o_q, properties_t("async", true));
 
         // output  (print from rkq)
-        // if (!rank) printf("\n");
         solver.Report(outputTime,tstep);
 
         // restore time step
@@ -677,17 +639,9 @@ void sark4_pml::Run(solver_t& solver,
       constexpr dfloat errMax = 1.0e-4;  // hard coded factor ?
       facold = std::max(err,errMax);
 
-      // if (!rank)
-      //   printf("\r time = %g (%d), dt = %g accepted                      ", time, allStep,  dt);
-
       tstep++;
     } else {
       dtnew = dt/(std::max(invfactor1,fac1/safe));
-
-      // if (!rank)
-      //   printf("\r time = %g (%d), dt = %g rejected, trying %g", time, allStep, dt, dtnew);
-      if (!rank)
-        printf("Repeating timestep %d. dt was %g, trying %g.\n", tstep, dt, dtnew);
     }
     dt = dtnew;
 
@@ -695,34 +649,28 @@ void sark4_pml::Run(solver_t& solver,
     UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
 
     // move data to platform
-    // o_rkX.copyFrom(rkX, properties_t("async", true));
-    // o_rkA.copyFrom(rkA, properties_t("async", true));
-    // o_rkE.copyFrom(rkE, properties_t("async", true));
-    h_rkX.copyTo(o_rkX);
-    h_rkA.copyTo(o_rkA);
-    h_rkE.copyTo(o_rkE);
+    h_rkX.copyTo(o_rkX, properties_t("async", true));
+    h_rkA.copyTo(o_rkA, properties_t("async", true));
+    h_rkE.copyTo(o_rkE, properties_t("async", true));
 
     allStep++;
   }
-
-  if (!rank)
-    printf("%d accepted steps and %d total steps\n", tstep, allStep);
 }
 
 void sark4_pml::Backup(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq) {
-  o_saveq.copyFrom(o_q, N);
-  o_savepmlq.copyFrom(o_rkpmlq, Npml);
+  o_saveq.copyFrom(o_q, N, properties_t("async", true));
+  o_savepmlq.copyFrom(o_rkpmlq, Npml, properties_t("async", true));
 }
 
 void sark4_pml::Restore(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq) {
-  o_saveq.copyTo(o_q, N);
-  o_savepmlq.copyTo(o_rkpmlq, Npml);
+  o_saveq.copyTo(o_q, N, properties_t("async", true));
+  o_savepmlq.copyTo(o_rkpmlq, Npml, properties_t("async", true));
 }
 
 void sark4_pml::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq,
                            deviceMemory<dfloat> &o_pmlq, deviceMemory<dfloat> &o_rpmlq) {
-  o_q.copyFrom(o_rq, N);
-  o_pmlq.copyFrom(o_rpmlq, Npml);
+  o_q.copyFrom(o_rq, N, properties_t("async", true));
+  o_pmlq.copyFrom(o_rpmlq, Npml, properties_t("async", true));
 }
 
 void sark4_pml::Step(solver_t& solver,

--- a/libs/timeStepper/timeStepperSARK4.cpp
+++ b/libs/timeStepper/timeStepperSARK4.cpp
@@ -35,404 +35,21 @@ namespace TimeStepper {
 
 using std::complex;
 
-static void UpdateCoefficients(const int Nfields,
-                               const memory<dfloat> &lambda,
-                               const dfloat dt,
-                               pinnedMemory<dfloat> &h_rkX,
-                               pinnedMemory<dfloat> &h_rkA,
-                               pinnedMemory<dfloat> &h_rkE);
-
 sark4::sark4(dlong _Nelements, dlong _NhaloElements,
              int _Np, int _Nfields,
              memory<dfloat> _lambda,
              platform_t& _platform, comm_t _comm):
-  timeStepperBase_t(_Nelements, _NhaloElements, _Np, _Nfields,
+  sark4(_Nelements, 0, _NhaloElements,
+        _Np, _Nfields, 0,
+        _lambda, _platform, _comm) {}
+
+sark4::sark4(dlong _Nelements, dlong NpmlElements, dlong _NhaloElements,
+             int _Np, int _Nfields, int _Npmlfields,
+             memory<dfloat> _lambda,
+             platform_t& _platform, comm_t _comm):
+  timeStepperBase_t(_Nelements, NpmlElements, _NhaloElements,
+                    _Np, _Nfields, _Npmlfields,
                     _platform, _comm),
-  Np(_Np),
-  Nfields(_Nfields),
-  Nelements(_Nelements),
-  NhaloElements(_NhaloElements) {
-
-  lambda.malloc(Nfields);
-  lambda.copyFrom(_lambda);
-
-  //Nrk = 5;
-  order = 4;
-  embeddedOrder = 3;
-
-  dlong Nlocal = Nelements*Np*Nfields;
-  dlong Ntotal = (Nelements+NhaloElements)*Np*Nfields;
-
-  o_rkq    = platform.malloc<dfloat>(Ntotal);
-  o_rhsq   = platform.malloc<dfloat>(Nlocal);
-  o_rkrhsq = platform.malloc<dfloat>(Nlocal*Nrk);
-  o_rkerr  = platform.malloc<dfloat>(Nlocal);
-
-  o_saveq  = platform.malloc<dfloat>(Nlocal);
-
-  const int blocksize=256;
-
-  Nblock = (N+blocksize-1)/blocksize;
-  h_errtmp = platform.hostMalloc<dfloat>(Nblock);
-  o_errtmp = platform.malloc<dfloat>(Nblock);
-
-  hlong gNtotal = Nlocal;
-  comm.Allreduce(gNtotal);
-
-  //copy base occa properties from platform
-  properties_t kernelInfo = platform.props();
-
-  //add defines
-  kernelInfo["defines/" "p_blockSize"] = (int)blocksize;
-  kernelInfo["defines/" "p_Nrk"]     = (int)Nrk;
-  kernelInfo["defines/" "p_Np"]      = (int)Np;
-  kernelInfo["defines/" "p_Nfields"] = (int)Nfields;
-
-  rkUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
-                                    "timeStepperSARK.okl",
-                                    "sarkRkUpdate",
-                                    kernelInfo);
-
-  rkStageKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
-                                    "timeStepperSARK.okl",
-                                    "sarkRkStage",
-                                    kernelInfo);
-
-  rkErrorEstimateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
-                                    "timeStepperSARK.okl",
-                                    "sarkErrorEstimate",
-                                    kernelInfo);
-
-  // Semi-Analytic Runge Kutta - order (3) 4 with PID timestep control
-  dfloat _rkC[Nrk] = {0.0, 0.5, 0.5, 1.0, 1.0};
-  rkC.malloc(Nrk);
-  rkC.copyFrom(_rkC);
-
-  h_rkX = platform.hostMalloc<dfloat>(Nfields*Nrk);
-  h_rkA = platform.hostMalloc<dfloat>(Nfields*Nrk*Nrk);
-  h_rkE = platform.hostMalloc<dfloat>(Nfields*Nrk);
-
-  o_rkX = platform.malloc<dfloat>(Nfields*Nrk);
-  o_rkA = platform.malloc<dfloat>(Nfields*Nrk*Nrk);
-  o_rkE = platform.malloc<dfloat>(Nfields*Nrk);
-
-  dtMIN = 1E-9; //minumum allowed timestep
-  ATOL = 1E-5;  //absolute error tolerance
-  RTOL = 1E-4;  //relative error tolerance
-  safe = 0.8;   //safety factor
-
-  //error control parameters
-  beta = 0.05;
-  factor1 = 0.2;
-  factor2 = 10.0;
-
-  exp1 = 1.0/(embeddedOrder+1) - 0.75*beta;
-  invfactor1 = 1.0/factor1;
-  invfactor2 = 1.0/factor2;
-  facold = 1E-4;
-  sqrtinvNtotal = 1.0/sqrt(gNtotal);
-}
-
-void sark4::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloat end) {
-
-  dfloat time = start;
-
-  solver.Report(time,0);
-
-  dfloat outputInterval=0.0;
-  solver.settings.getSetting("OUTPUT INTERVAL", outputInterval);
-
-  dfloat outputTime = time + outputInterval;
-
-  int tstep=0, allStep=0;
-
-  //Compute Butcher Tableau
-  UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
-
-  // move data to platform
-  h_rkX.copyTo(o_rkX, properties_t("async", true));
-  h_rkA.copyTo(o_rkA, properties_t("async", true));
-  h_rkE.copyTo(o_rkE, properties_t("async", true));
-
-  while (time < end) {
-
-    LIBP_ABORT("Time step became too small at time step = " << tstep,
-               dt<dtMIN);
-    LIBP_ABORT("Solution became unstable at time step = " << tstep,
-               std::isnan(dt));
-
-    //check for final timestep
-    if (time+dt > end){
-      dt = end-time;
-    }
-
-    Step(solver, o_q, time, dt);
-
-    // compute Dopri estimator
-    dfloat err = Estimater(o_q);
-
-    // build controller
-    dfloat fac1 = pow(err,exp1);
-    dfloat fac = fac1/pow(facold,beta);
-
-    fac = std::max(invfactor2, std::min(invfactor1,fac/safe));
-    dfloat dtnew = dt/fac;
-
-    if (err<1.0) { //dt is accepted
-
-      // check for output during this step and do a mini-step
-      if (time<outputTime && time+dt>=outputTime) {
-        dfloat savedt = dt;
-
-        // save rkq
-        Backup(o_rkq);
-
-        // change dt to match output
-        dt = outputTime-time;
-
-        //Compute Butcher Tableau
-        UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
-
-        // move data to platform
-        h_rkX.copyTo(o_rkX, properties_t("async", true));
-        h_rkA.copyTo(o_rkA, properties_t("async", true));
-        h_rkE.copyTo(o_rkE, properties_t("async", true));
-
-        // time step to output
-        Step(solver, o_q, time, dt);
-
-        // shift for output
-        o_rkq.copyTo(o_q, properties_t("async", true));
-
-        // output  (print from rkq)
-        solver.Report(outputTime,tstep);
-
-        // restore time step
-        dt = savedt;
-
-        // increment next output time
-        outputTime += outputInterval;
-
-        // accept saved rkq
-        Restore(o_rkq);
-        AcceptStep(o_q, o_rkq);
-
-      } else {
-        // accept rkq
-        AcceptStep(o_q, o_rkq);
-      }
-
-      time += dt;
-      while (time>outputTime) outputTime+= outputInterval; //catch up next output in case dt>outputInterval
-
-      constexpr dfloat errMax = 1.0e-4;  // hard coded factor ?
-      facold = std::max(err,errMax);
-
-      tstep++;
-    } else {
-      dtnew = dt/(std::max(invfactor1,fac1/safe));
-    }
-    dt = dtnew;
-
-    //Compute Butcher Tableau
-    UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
-
-    // move data to platform
-    h_rkX.copyTo(o_rkX, properties_t("async", true));
-    h_rkA.copyTo(o_rkA, properties_t("async", true));
-    h_rkE.copyTo(o_rkE, properties_t("async", true));
-
-    allStep++;
-  }
-}
-
-void sark4::Backup(deviceMemory<dfloat> &o_q) {
-  o_saveq.copyFrom(o_q, N, properties_t("async", true));
-}
-
-void sark4::Restore(deviceMemory<dfloat> &o_q) {
-  o_saveq.copyTo(o_q, N, properties_t("async", true));
-}
-
-void sark4::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq) {
-  o_q.copyFrom(o_rq, N, properties_t("async", true));
-}
-
-void sark4::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloat _dt) {
-
-  //RK step
-  for(int rk=0;rk<Nrk;++rk){
-
-    // t_rk = t + C_rk*_dt
-    dfloat currentTime = time + rkC[rk]*_dt;
-
-    //compute RK stage
-    // rkq = x_{rk}*q + _dt sum_{i=0}^{rk-1} a_{rk,i}*rhsq_i
-    rkStageKernel(Nelements,
-                  rk,
-                  _dt,
-                  o_rkX,
-                  o_rkA,
-                  o_q,
-                  o_rkrhsq,
-                  o_rkq);
-
-    //evaluate ODE rhs = f(q,t)
-    solver.rhsf(o_rkq, o_rhsq, currentTime);
-
-    // update solution using Runge-Kutta
-    // rkrhsq_rk = rhsq
-    // if rk==6
-    //   q = rkX_{rk}*q + _dt*sum_{i=0}^{rk} rkA_{rk,i}*rkrhs_i
-    //   rkerr = _dt*sum_{i=0}^{rk} rkE_{rk,i}*rkrhs_i
-    rkUpdateKernel(Nelements,
-                   rk,
-                   _dt,
-                   o_rkX,
-                   o_rkA,
-                   o_rkE,
-                   o_q,
-                   o_rhsq,
-                   o_rkrhsq,
-                   o_rkq,
-                   o_rkerr);
-  }
-}
-
-dfloat sark4::Estimater(deviceMemory<dfloat>& o_q){
-
-  //Error estimation
-  //E. HAIRER, S.P. NORSETT AND G. WANNER, SOLVING ORDINARY
-  //      DIFFERENTIAL EQUATIONS I. NONSTIFF PROBLEMS. 2ND EDITION.
-  rkErrorEstimateKernel(Nelements*Np*Nfields,
-                        ATOL,
-                        RTOL,
-                        o_q,
-                        o_rkq,
-                        o_rkerr,
-                        o_errtmp);
-
-  h_errtmp.copyFrom(o_errtmp);
-  dfloat err = 0;
-  for(dlong n=0;n<Nblock;++n){
-    err += h_errtmp[n];
-  }
-  comm.Allreduce(err);
-
-  err = sqrt(err)*sqrtinvNtotal;
-
-  return err;
-}
-
-static void UpdateCoefficients(const int Nfields,
-                               const memory<dfloat> &lambda,
-                               const dfloat dt,
-                               pinnedMemory<dfloat> &h_rkX,
-                               pinnedMemory<dfloat> &h_rkA,
-                               pinnedMemory<dfloat> &h_rkE) {
-
-  constexpr int Nrk = 5;
-  const int Nr = 32;
-  complex<dfloat> R[Nr];
-
-  //contour integral integration points
-  for(int ind=1; ind <= Nr; ++ind){
-    const dfloat theta = (dfloat) (ind - 0.5) / (dfloat) Nr;
-    complex<dfloat> z(0., M_PI* theta);
-    R[ind-1] = exp(z);
-  }
-
-  for (int n=0;n<Nfields;n++) {
-
-    dfloat* rkX = h_rkX.ptr() + n * Nrk;
-    dfloat* rkA = h_rkA.ptr() + n * Nrk * Nrk;
-    dfloat* rkE = h_rkE.ptr() + n * Nrk;
-
-    if (lambda[n]==0) { //Zero exponential term, usual RK coefficients
-
-      rkX[0] = 1.0; rkX[1] = 1.0; rkX[2] = 1.0; rkX[3] = 1.0; rkX[4] = 1.0;
-
-      rkA[0+0*Nrk] =     0.0; rkA[1+0*Nrk] =     0.0; rkA[2+0*Nrk] =     0.0; rkA[3+0*Nrk] =     0.0; rkA[4+0*Nrk] = 0.0;
-      rkA[0+1*Nrk] =     0.5; rkA[1+1*Nrk] =     0.0; rkA[2+1*Nrk] =     0.0; rkA[3+1*Nrk] =     0.0; rkA[4+1*Nrk] = 0.0;
-      rkA[0+2*Nrk] =     0.0; rkA[1+2*Nrk] =     0.5; rkA[2+2*Nrk] =     0.0; rkA[3+2*Nrk] =     0.0; rkA[4+2*Nrk] = 0.0;
-      rkA[0+3*Nrk] =     0.0; rkA[1+3*Nrk] =     0.0; rkA[2+3*Nrk] =     1.0; rkA[3+3*Nrk] =     0.0; rkA[4+3*Nrk] = 0.0;
-      rkA[0+4*Nrk] = 1.0/6.0; rkA[1+4*Nrk] = 1.0/3.0; rkA[2+4*Nrk] = 1.0/3.0; rkA[3+4*Nrk] = 1.0/6.0; rkA[4+4*Nrk] = 0.0;
-
-      rkE[0] = 0.0; rkE[1] = 0.0; rkE[2] = 0.0; rkE[3] = -1.0/6.0; rkE[4] = 1.0/6.0;
-
-    } else {
-
-      //Compute RK coefficients via contour integral
-      dfloat alpha = lambda[n]*dt;
-
-      // Initialize complex variables for contour integral
-      complex<double> ca21(0.,0.);
-      complex<double> ca31(0.,0.);
-      complex<double> ca32(0.,0.);
-      complex<double> ca41(0.,0.);
-      complex<double> ca43(0.,0.);
-      complex<double> ca51(0.,0.);
-      complex<double> ca52(0.,0.);
-      complex<double> ca53(0.,0.);
-      complex<double> ca54(0.,0.);
-
-      for(int i = 0; i<Nr; ++i ){
-        complex<double> lr = alpha  + R[i];
-
-        ca21 +=  (exp(lr/2.) - 1.)/lr;
-
-        ca31 +=  (4. + exp(lr/2.)*(-4. + lr) + lr)/pow(lr,2);
-        ca32 +=  (4.*exp(lr/2.) -2.*lr -4.)/pow(lr,2);
-
-        ca41 +=  ((exp(lr) + 1.)*lr + 2. - 2.*exp(lr))/pow(lr,2);
-        ca43 +=  (2.*exp(lr) - 2.*lr - 2.)/pow(lr,2);
-
-        ca51 +=  (exp(lr)*pow(lr,2) + (- 3.*exp(lr) - 1.)*lr + 4.*exp(lr) - 4.)/pow(lr,3);
-        ca52 +=  ((2.*exp(lr) + 2.)*lr + 4. - 4.*exp(lr))/pow(lr,3);
-        ca53 +=  ((2.*exp(lr) + 2.)*lr + 4. - 4.*exp(lr))/pow(lr,3);
-        ca54 +=  ((-exp(lr) - 3.)*lr - pow(lr,2) + 4.*exp(lr) - 4.)/pow(lr,3);
-      }
-
-
-      dfloat a21=real(ca21)/ (double) Nr;
-
-      dfloat a31=real(ca31)/ (double) Nr;
-      dfloat a32=real(ca32)/ (double) Nr;
-
-      dfloat a41=real(ca41)/ (double) Nr;
-      dfloat a43=real(ca43)/ (double) Nr;
-
-      dfloat a51=real(ca51)/ (double) Nr;
-      dfloat a52=real(ca52)/ (double) Nr;
-      dfloat a53=real(ca53)/ (double) Nr;
-      dfloat a54=real(ca54)/ (double) Nr;
-
-      // first set non-semianalytic part of the integrator
-      rkX[0] = 1.0; rkX[1] = std::exp(dfloat(0.5)*alpha); rkX[2] = std::exp(dfloat(0.5)*alpha); rkX[3] = std::exp(alpha); rkX[4] = std::exp(alpha);
-
-      rkA[0+0*Nrk] = 0.0; rkA[1+0*Nrk] = 0.0; rkA[2+0*Nrk] = 0.0; rkA[3+0*Nrk] = 0.0; rkA[4+0*Nrk] = 0.0;
-      rkA[0+1*Nrk] = a21; rkA[1+1*Nrk] = 0.0; rkA[2+1*Nrk] = 0.0; rkA[3+1*Nrk] = 0.0; rkA[4+1*Nrk] = 0.0;
-      rkA[0+2*Nrk] = a31; rkA[1+2*Nrk] = a32; rkA[2+2*Nrk] = 0.0; rkA[3+2*Nrk] = 0.0; rkA[4+2*Nrk] = 0.0;
-      rkA[0+3*Nrk] = a41; rkA[1+3*Nrk] = 0.0; rkA[2+3*Nrk] = a43; rkA[3+3*Nrk] = 0.0; rkA[4+3*Nrk] = 0.0;
-      rkA[0+4*Nrk] = a51; rkA[1+4*Nrk] = a52; rkA[2+4*Nrk] = a53; rkA[3+4*Nrk] = a54; rkA[4+4*Nrk] = 0.0;
-
-      rkE[0] = 0.0; rkE[1] = 0.0; rkE[2] = 0.0; rkE[3] = -a54; rkE[4] = a54;
-    }
-  }
-}
-
-
-/**************************************************/
-/* PML version                                    */
-/**************************************************/
-
-sark4_pml::sark4_pml(dlong _Nelements, dlong NpmlElements, dlong _NhaloElements,
-                     int _Np, int _Nfields, int _Npmlfields,
-                     memory<dfloat> _lambda,
-                     platform_t& _platform, comm_t _comm):
-  pmlTimeStepperBase_t(_Nelements, NpmlElements, _NhaloElements,
-                       _Np, _Nfields, _Npmlfields,
-                       _platform, _comm),
   Np(_Np),
   Nfields(_Nfields),
   Nelements(_Nelements),
@@ -541,10 +158,10 @@ sark4_pml::sark4_pml(dlong _Nelements, dlong NpmlElements, dlong _NhaloElements,
   sqrtinvNtotal = 1.0/sqrt(gNtotal);
 }
 
-void sark4_pml::Run(solver_t& solver,
-                    deviceMemory<dfloat> &o_q,
-                    deviceMemory<dfloat> &o_pmlq,
-                    dfloat start, dfloat end) {
+void sark4::Run(solver_t& solver,
+                deviceMemory<dfloat> o_q,
+                std::optional<deviceMemory<dfloat>> o_pmlq,
+                dfloat start, dfloat end) {
 
   dfloat time = start;
 
@@ -558,12 +175,7 @@ void sark4_pml::Run(solver_t& solver,
   int tstep=0, allStep=0;
 
   //Compute Butcher Tableau
-  UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
-
-  // move data to platform
-  h_rkX.copyTo(o_rkX, properties_t("async", true));
-  h_rkA.copyTo(o_rkA, properties_t("async", true));
-  h_rkE.copyTo(o_rkE, properties_t("async", true));
+  UpdateCoefficients();
 
   while (time < end) {
 
@@ -596,24 +208,25 @@ void sark4_pml::Run(solver_t& solver,
         dfloat savedt = dt;
 
         // save rkq
-        Backup(o_rkq, o_rkpmlq);
+        o_saveq.copyFrom(o_rkq, N, properties_t("async", true));
+        if (o_pmlq.has_value()) {
+          o_savepmlq.copyFrom(o_rkpmlq, Npml, properties_t("async", true));
+        }
 
         // change dt to match output
         dt = outputTime-time;
 
         //Compute Butcher Tableau
-        UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
-
-        // move data to platform
-        h_rkX.copyTo(o_rkX, properties_t("async", true));
-        h_rkA.copyTo(o_rkA, properties_t("async", true));
-        h_rkE.copyTo(o_rkE, properties_t("async", true));
+        UpdateCoefficients();
 
         // time step to output
         Step(solver, o_q, o_pmlq, time, dt);
 
         // shift for output
         o_rkq.copyTo(o_q, properties_t("async", true));
+        if (o_pmlq.has_value()) {
+          o_rkpmlq.copyTo(o_pmlq.value(), properties_t("async", true));
+        }
 
         // output  (print from rkq)
         solver.Report(outputTime,tstep);
@@ -625,12 +238,16 @@ void sark4_pml::Run(solver_t& solver,
         outputTime += outputInterval;
 
         // accept saved rkq
-        Restore(o_rkq, o_rkpmlq);
-        AcceptStep(o_q, o_rkq, o_pmlq, o_rkpmlq);
-
+        o_saveq.copyTo(o_q, N, properties_t("async", true));
+        if (o_pmlq.has_value()) {
+          o_savepmlq.copyTo(o_pmlq.value(), Npml, properties_t("async", true));
+        }
       } else {
         // accept rkq
-        AcceptStep(o_q, o_rkq, o_pmlq, o_rkpmlq);
+        o_q.copyFrom(o_rkq, N, properties_t("async", true));
+        if (o_pmlq.has_value()) {
+          o_pmlq.value().copyFrom(o_rkpmlq, Npml, properties_t("async", true));
+        }
       }
 
       time += dt;
@@ -646,37 +263,16 @@ void sark4_pml::Run(solver_t& solver,
     dt = dtnew;
 
     //Compute Butcher Tableau
-    UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
-
-    // move data to platform
-    h_rkX.copyTo(o_rkX, properties_t("async", true));
-    h_rkA.copyTo(o_rkA, properties_t("async", true));
-    h_rkE.copyTo(o_rkE, properties_t("async", true));
+    UpdateCoefficients();
 
     allStep++;
   }
 }
 
-void sark4_pml::Backup(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq) {
-  o_saveq.copyFrom(o_q, N, properties_t("async", true));
-  o_savepmlq.copyFrom(o_rkpmlq, Npml, properties_t("async", true));
-}
-
-void sark4_pml::Restore(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq) {
-  o_saveq.copyTo(o_q, N, properties_t("async", true));
-  o_savepmlq.copyTo(o_rkpmlq, Npml, properties_t("async", true));
-}
-
-void sark4_pml::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq,
-                           deviceMemory<dfloat> &o_pmlq, deviceMemory<dfloat> &o_rpmlq) {
-  o_q.copyFrom(o_rq, N, properties_t("async", true));
-  o_pmlq.copyFrom(o_rpmlq, Npml, properties_t("async", true));
-}
-
-void sark4_pml::Step(solver_t& solver,
-                     deviceMemory<dfloat> &o_q,
-                     deviceMemory<dfloat> &o_pmlq,
-                     dfloat time, dfloat _dt) {
+void sark4::Step(solver_t& solver,
+                 deviceMemory<dfloat> o_q,
+                 std::optional<deviceMemory<dfloat>> o_pmlq,
+                 dfloat time, dfloat _dt) {
 
   //RK step
   for(int rk=0;rk<Nrk;++rk){
@@ -694,17 +290,22 @@ void sark4_pml::Step(solver_t& solver,
                   o_q,
                   o_rkrhsq,
                   o_rkq);
-    if (Npml)
+    if (o_pmlq.has_value()) {
       rkPmlStageKernel(Npml,
                       rk,
                       _dt,
                       o_pmlrkA,
-                      o_pmlq,
+                      o_pmlq.value(),
                       o_rkrhspmlq,
                       o_rkpmlq);
+    }
 
     //evaluate ODE rhs = f(q,t)
-    solver.rhsf_pml(o_rkq, o_rkpmlq, o_rhsq, o_rhspmlq, currentTime);
+    if (o_pmlq.has_value()) {
+      solver.rhsf_pml(o_rkq, o_rkpmlq, o_rhsq, o_rhspmlq, currentTime);
+    } else {
+      solver.rhsf(o_rkq, o_rhsq, currentTime);
+    }
 
     // update solution using Runge-Kutta
     // rkrhsq_rk = rhsq
@@ -722,19 +323,20 @@ void sark4_pml::Step(solver_t& solver,
                    o_rkrhsq,
                    o_rkq,
                    o_rkerr);
-    if (Npml)
+    if (o_pmlq.has_value()) {
       rkPmlUpdateKernel(Npml,
                          rk,
                          _dt,
                          o_pmlrkA,
-                         o_pmlq,
+                         o_pmlq.value(),
                          o_rhspmlq,
                          o_rkrhspmlq,
                          o_rkpmlq);
+    }
   }
 }
 
-dfloat sark4_pml::Estimater(deviceMemory<dfloat>& o_q){
+dfloat sark4::Estimater(deviceMemory<dfloat>& o_q){
 
   //Error estimation
   //E. HAIRER, S.P. NORSETT AND G. WANNER, SOLVING ORDINARY
@@ -758,6 +360,103 @@ dfloat sark4_pml::Estimater(deviceMemory<dfloat>& o_q){
 
   return err;
 }
+
+void sark4::UpdateCoefficients() {
+
+  const int Nr = 32;
+  complex<dfloat> R[Nr];
+
+  //contour integral integration points
+  for(int ind=1; ind <= Nr; ++ind){
+    const dfloat theta = (dfloat) (ind - 0.5) / (dfloat) Nr;
+    complex<dfloat> z(0., M_PI* theta);
+    R[ind-1] = exp(z);
+  }
+
+  for (int n=0;n<Nfields;n++) {
+
+    dfloat* rkX = h_rkX.ptr() + n * Nrk;
+    dfloat* rkA = h_rkA.ptr() + n * Nrk * Nrk;
+    dfloat* rkE = h_rkE.ptr() + n * Nrk;
+
+    if (lambda[n]==0) { //Zero exponential term, usual RK coefficients
+
+      rkX[0] = 1.0; rkX[1] = 1.0; rkX[2] = 1.0; rkX[3] = 1.0; rkX[4] = 1.0;
+
+      rkA[0+0*Nrk] =     0.0; rkA[1+0*Nrk] =     0.0; rkA[2+0*Nrk] =     0.0; rkA[3+0*Nrk] =     0.0; rkA[4+0*Nrk] = 0.0;
+      rkA[0+1*Nrk] =     0.5; rkA[1+1*Nrk] =     0.0; rkA[2+1*Nrk] =     0.0; rkA[3+1*Nrk] =     0.0; rkA[4+1*Nrk] = 0.0;
+      rkA[0+2*Nrk] =     0.0; rkA[1+2*Nrk] =     0.5; rkA[2+2*Nrk] =     0.0; rkA[3+2*Nrk] =     0.0; rkA[4+2*Nrk] = 0.0;
+      rkA[0+3*Nrk] =     0.0; rkA[1+3*Nrk] =     0.0; rkA[2+3*Nrk] =     1.0; rkA[3+3*Nrk] =     0.0; rkA[4+3*Nrk] = 0.0;
+      rkA[0+4*Nrk] = 1.0/6.0; rkA[1+4*Nrk] = 1.0/3.0; rkA[2+4*Nrk] = 1.0/3.0; rkA[3+4*Nrk] = 1.0/6.0; rkA[4+4*Nrk] = 0.0;
+
+      rkE[0] = 0.0; rkE[1] = 0.0; rkE[2] = 0.0; rkE[3] = -1.0/6.0; rkE[4] = 1.0/6.0;
+
+    } else {
+
+      //Compute RK coefficients via contour integral
+      dfloat alpha = lambda[n]*dt;
+
+      // Initialize complex variables for contour integral
+      complex<double> ca21(0.,0.);
+      complex<double> ca31(0.,0.);
+      complex<double> ca32(0.,0.);
+      complex<double> ca41(0.,0.);
+      complex<double> ca43(0.,0.);
+      complex<double> ca51(0.,0.);
+      complex<double> ca52(0.,0.);
+      complex<double> ca53(0.,0.);
+      complex<double> ca54(0.,0.);
+
+      for(int i = 0; i<Nr; ++i ){
+        complex<double> lr = alpha  + R[i];
+
+        ca21 +=  (exp(lr/2.) - 1.)/lr;
+
+        ca31 +=  (4. + exp(lr/2.)*(-4. + lr) + lr)/pow(lr,2);
+        ca32 +=  (4.*exp(lr/2.) -2.*lr -4.)/pow(lr,2);
+
+        ca41 +=  ((exp(lr) + 1.)*lr + 2. - 2.*exp(lr))/pow(lr,2);
+        ca43 +=  (2.*exp(lr) - 2.*lr - 2.)/pow(lr,2);
+
+        ca51 +=  (exp(lr)*pow(lr,2) + (- 3.*exp(lr) - 1.)*lr + 4.*exp(lr) - 4.)/pow(lr,3);
+        ca52 +=  ((2.*exp(lr) + 2.)*lr + 4. - 4.*exp(lr))/pow(lr,3);
+        ca53 +=  ((2.*exp(lr) + 2.)*lr + 4. - 4.*exp(lr))/pow(lr,3);
+        ca54 +=  ((-exp(lr) - 3.)*lr - pow(lr,2) + 4.*exp(lr) - 4.)/pow(lr,3);
+      }
+
+
+      dfloat a21=real(ca21)/ (double) Nr;
+
+      dfloat a31=real(ca31)/ (double) Nr;
+      dfloat a32=real(ca32)/ (double) Nr;
+
+      dfloat a41=real(ca41)/ (double) Nr;
+      dfloat a43=real(ca43)/ (double) Nr;
+
+      dfloat a51=real(ca51)/ (double) Nr;
+      dfloat a52=real(ca52)/ (double) Nr;
+      dfloat a53=real(ca53)/ (double) Nr;
+      dfloat a54=real(ca54)/ (double) Nr;
+
+      // first set non-semianalytic part of the integrator
+      rkX[0] = 1.0; rkX[1] = std::exp(dfloat(0.5)*alpha); rkX[2] = std::exp(dfloat(0.5)*alpha); rkX[3] = std::exp(alpha); rkX[4] = std::exp(alpha);
+
+      rkA[0+0*Nrk] = 0.0; rkA[1+0*Nrk] = 0.0; rkA[2+0*Nrk] = 0.0; rkA[3+0*Nrk] = 0.0; rkA[4+0*Nrk] = 0.0;
+      rkA[0+1*Nrk] = a21; rkA[1+1*Nrk] = 0.0; rkA[2+1*Nrk] = 0.0; rkA[3+1*Nrk] = 0.0; rkA[4+1*Nrk] = 0.0;
+      rkA[0+2*Nrk] = a31; rkA[1+2*Nrk] = a32; rkA[2+2*Nrk] = 0.0; rkA[3+2*Nrk] = 0.0; rkA[4+2*Nrk] = 0.0;
+      rkA[0+3*Nrk] = a41; rkA[1+3*Nrk] = 0.0; rkA[2+3*Nrk] = a43; rkA[3+3*Nrk] = 0.0; rkA[4+3*Nrk] = 0.0;
+      rkA[0+4*Nrk] = a51; rkA[1+4*Nrk] = a52; rkA[2+4*Nrk] = a53; rkA[3+4*Nrk] = a54; rkA[4+4*Nrk] = 0.0;
+
+      rkE[0] = 0.0; rkE[1] = 0.0; rkE[2] = 0.0; rkE[3] = -a54; rkE[4] = a54;
+    }
+  }
+
+  // move data to platform
+  h_rkX.copyTo(o_rkX, properties_t("async", true));
+  h_rkA.copyTo(o_rkA, properties_t("async", true));
+  h_rkE.copyTo(o_rkE, properties_t("async", true));
+}
+
 
 } //namespace TimeStepper
 

--- a/libs/timeStepper/timeStepperSARK5.cpp
+++ b/libs/timeStepper/timeStepperSARK5.cpp
@@ -35,18 +35,20 @@ namespace TimeStepper {
 
 using std::complex;
 
-static void UpdateCoefficients(const int Nfields,
-                               const memory<dfloat> &lambda,
-                               const dfloat dt,
-                               pinnedMemory<dfloat> &h_rkX,
-                               pinnedMemory<dfloat> &h_rkA,
-                               pinnedMemory<dfloat> &h_rkE);
-
 sark5::sark5(dlong _Nelements, dlong _NhaloElements,
              int _Np, int _Nfields,
              memory<dfloat> _lambda,
              platform_t& _platform, comm_t _comm):
-  timeStepperBase_t(_Nelements, _NhaloElements, _Np, _Nfields,
+  sark5(_Nelements, 0, _NhaloElements,
+        _Np, _Nfields, 0,
+        _lambda, _platform, _comm) {}
+
+sark5::sark5(dlong _Nelements, dlong NpmlElements, dlong _NhaloElements,
+             int _Np, int _Nfields, int Npmlfields,
+             memory<dfloat> _lambda,
+             platform_t& _platform, comm_t _comm):
+  timeStepperBase_t(_Nelements, NpmlElements, _NhaloElements,
+                    _Np, _Nfields, Npmlfields,
                     _platform, _comm),
   Np(_Np),
   Nfields(_Nfields),
@@ -66,9 +68,14 @@ sark5::sark5(dlong _Nelements, dlong _NhaloElements,
   o_rkq    = platform.malloc<dfloat>(Ntotal);
   o_rhsq   = platform.malloc<dfloat>(Nlocal);
   o_rkrhsq = platform.malloc<dfloat>(Nlocal*Nrk);
+  o_rkpmlq    = platform.malloc<dfloat>(Npml);
+  o_rhspmlq   = platform.malloc<dfloat>(Npml);
+  o_rkrhspmlq = platform.malloc<dfloat>(Npml*Nrk);
+
   o_rkerr  = platform.malloc<dfloat>(Nlocal);
 
   o_saveq  = platform.malloc<dfloat>(Nlocal);
+  o_savepmlq   = platform.malloc<dfloat>(Npml);
 
   const int blocksize=256;
 
@@ -91,12 +98,18 @@ sark5::sark5(dlong _Nelements, dlong _NhaloElements,
                                     "timeStepperSARK.okl",
                                     "sarkRkUpdate",
                                     kernelInfo);
-
+  rkPmlUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+                                      "timeStepperSARK.okl",
+                                      "sarkRkPmlUpdate",
+                                      kernelInfo);
   rkStageKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
                                     "timeStepperSARK.okl",
                                     "sarkRkStage",
                                     kernelInfo);
-
+  rkPmlStageKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+                                      "timeStepperSARK.okl",
+                                      "sarkRkPmlStage",
+                                      kernelInfo);
   rkErrorEstimateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
                                     "timeStepperSARK.okl",
                                     "sarkErrorEstimate",
@@ -115,6 +128,20 @@ sark5::sark5(dlong _Nelements, dlong _NhaloElements,
   o_rkA = platform.malloc<dfloat>(Nfields*Nrk*Nrk);
   o_rkE = platform.malloc<dfloat>(Nfields*Nrk);
 
+  pmlrkA.malloc(Nrk*Nrk);
+
+  dfloat _pmlrkA[Nrk*Nrk] =  {     0,      0,       0,       0,       0,      0,   0,
+                                 1/4,      0,       0,       0,       0,      0,   0,
+                                 1/8,    1/8,       0,       0,       0,      0,   0,
+                                   0,      0,     1/2,       0,       0,      0,   0,
+                              3./16., -3./8.,   3./8.,  9./16.,       0,      0,   0,
+                              -3./7.,  8./7.,   6./7., -12./7.,   8./7.,      0,   0,
+                              7./90.,     0., 16./45.,  2./15., 16./45., 7./90.,   0};
+
+  pmlrkA.copyFrom(_pmlrkA);
+
+  o_pmlrkA = platform.malloc<dfloat>(pmlrkA);
+
   dtMIN = 1E-9; //minumum allowed timestep
   ATOL = 1E-5;  //absolute error tolerance
   RTOL = 1E-4;  //relative error tolerance
@@ -132,7 +159,10 @@ sark5::sark5(dlong _Nelements, dlong _NhaloElements,
   sqrtinvNtotal = 1.0/sqrt(gNtotal);
 }
 
-void sark5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloat end) {
+void sark5::Run(solver_t& solver,
+                deviceMemory<dfloat> o_q,
+                std::optional<deviceMemory<dfloat>> o_pmlq,
+                dfloat start, dfloat end) {
 
   dfloat time = start;
 
@@ -146,12 +176,7 @@ void sark5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
   int tstep=0, allStep=0;
 
   //Compute Butcher Tableau
-  UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
-
-  // move data to platform
-  h_rkX.copyTo(o_rkX, properties_t("async", true));
-  h_rkA.copyTo(o_rkA, properties_t("async", true));
-  h_rkE.copyTo(o_rkE, properties_t("async", true));
+  UpdateCoefficients();
 
   while (time < end) {
 
@@ -165,7 +190,7 @@ void sark5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
       dt = end-time;
     }
 
-    Step(solver, o_q, time, dt);
+    Step(solver, o_q, o_pmlq, time, dt);
 
     // compute Dopri estimator
     dfloat err = Estimater(o_q);
@@ -184,24 +209,25 @@ void sark5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
         dfloat savedt = dt;
 
         // save rkq
-        Backup(o_rkq);
+        o_saveq.copyFrom(o_rkq, N, properties_t("async", true));
+        if (o_pmlq.has_value()) {
+          o_savepmlq.copyFrom(o_rkpmlq, Npml, properties_t("async", true));
+        }
 
         // change dt to match output
         dt = outputTime-time;
 
         //Compute Butcher Tableau
-        UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
-
-        // move data to platform
-        h_rkX.copyTo(o_rkX, properties_t("async", true));
-        h_rkA.copyTo(o_rkA, properties_t("async", true));
-        h_rkE.copyTo(o_rkE, properties_t("async", true));
+        UpdateCoefficients();
 
         // time step to output
-        Step(solver, o_q, time, dt);
+        Step(solver, o_q, o_pmlq, time, dt);
 
         // shift for output
         o_rkq.copyTo(o_q, properties_t("async", true));
+        if (o_pmlq.has_value()) {
+          o_rkpmlq.copyTo(o_pmlq.value(), properties_t("async", true));
+        }
 
         // output  (print from rkq)
         solver.Report(outputTime,tstep);
@@ -213,12 +239,16 @@ void sark5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
         outputTime += outputInterval;
 
         // accept saved rkq
-        Restore(o_rkq);
-        AcceptStep(o_q, o_rkq);
-
+        o_saveq.copyTo(o_q, N, properties_t("async", true));
+        if (o_pmlq.has_value()) {
+          o_savepmlq.copyTo(o_pmlq.value(), Npml, properties_t("async", true));
+        }
       } else {
         // accept rkq
-        AcceptStep(o_q, o_rkq);
+        o_q.copyFrom(o_rkq, N, properties_t("async", true));
+        if (o_pmlq.has_value()) {
+          o_pmlq.value().copyFrom(o_rkpmlq, Npml, properties_t("async", true));
+        }
       }
 
       time += dt;
@@ -234,30 +264,16 @@ void sark5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
     dt = dtnew;
 
     //Compute Butcher Tableau
-    UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
-
-    // move data to platform
-    h_rkX.copyTo(o_rkX, properties_t("async", true));
-    h_rkA.copyTo(o_rkA, properties_t("async", true));
-    h_rkE.copyTo(o_rkE, properties_t("async", true));
+    UpdateCoefficients();
 
     allStep++;
   }
 }
 
-void sark5::Backup(deviceMemory<dfloat> &o_q) {
-  o_saveq.copyFrom(o_q, N, properties_t("async", true));
-}
-
-void sark5::Restore(deviceMemory<dfloat> &o_q) {
-  o_saveq.copyTo(o_q, N, properties_t("async", true));
-}
-
-void sark5::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq) {
-  o_q.copyFrom(o_rq, N, properties_t("async", true));
-}
-
-void sark5::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloat _dt) {
+void sark5::Step(solver_t& solver,
+                 deviceMemory<dfloat> o_q,
+                 std::optional<deviceMemory<dfloat>> o_pmlq,
+                 dfloat time, dfloat _dt) {
 
   //RK step
   for(int rk=0;rk<Nrk;++rk){
@@ -275,9 +291,22 @@ void sark5::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloa
                   o_q,
                   o_rkrhsq,
                   o_rkq);
+    if (o_pmlq.has_value()) {
+      rkPmlStageKernel(Npml,
+                      rk,
+                      _dt,
+                      o_pmlrkA,
+                      o_pmlq.value(),
+                      o_rkrhspmlq,
+                      o_rkpmlq);
+    }
 
     //evaluate ODE rhs = f(q,t)
-    solver.rhsf(o_rkq, o_rhsq, currentTime);
+    if (o_pmlq.has_value()) {
+      solver.rhsf_pml(o_rkq, o_rkpmlq, o_rhsq, o_rhspmlq, currentTime);
+    } else {
+      solver.rhsf(o_rkq, o_rhsq, currentTime);
+    }
 
     // update solution using Runge-Kutta
     // rkrhsq_rk = rhsq
@@ -295,6 +324,16 @@ void sark5::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloa
                    o_rkrhsq,
                    o_rkq,
                    o_rkerr);
+    if (o_pmlq.has_value()) {
+      rkPmlUpdateKernel(Npml,
+                         rk,
+                         _dt,
+                         o_pmlrkA,
+                         o_pmlq.value(),
+                         o_rhspmlq,
+                         o_rkrhspmlq,
+                         o_rkpmlq);
+    }
   }
 }
 
@@ -323,14 +362,8 @@ dfloat sark5::Estimater(deviceMemory<dfloat>& o_q){
   return err;
 }
 
-static void UpdateCoefficients(const int Nfields,
-                               const memory<dfloat> &lambda,
-                               const dfloat dt,
-                               pinnedMemory<dfloat> &h_rkX,
-                               pinnedMemory<dfloat> &h_rkA,
-                               pinnedMemory<dfloat> &h_rkE) {
+void sark5::UpdateCoefficients() {
 
-  constexpr int Nrk = 7;
   const int Nr = 32;
   complex<dfloat> R[Nr];
 
@@ -474,344 +507,11 @@ static void UpdateCoefficients(const int Nfields,
       rkE[0] = b1; rkE[1] = 0.; rkE[2] = b3; rkE[3] = b4; rkE[4] = a75; rkE[5] = b6; rkE[6] = 0.;
     }
   }
-}
-
-/**************************************************/
-/* PML version                                    */
-/**************************************************/
-
-sark5_pml::sark5_pml(dlong _Nelements, dlong NpmlElements, dlong _NhaloElements,
-                     int _Np, int _Nfields, int Npmlfields,
-                     memory<dfloat> _lambda,
-                     platform_t& _platform, comm_t _comm):
-  pmlTimeStepperBase_t(_Nelements, NpmlElements, _NhaloElements,
-                       _Np, _Nfields, Npmlfields,
-                       _platform, _comm),
-  Np(_Np),
-  Nfields(_Nfields),
-  Nelements(_Nelements),
-  NhaloElements(_NhaloElements) {
-
-  lambda.malloc(Nfields);
-  lambda.copyFrom(_lambda);
-
-  //Nrk = 7; //number of stages
-  order = 5;
-  embeddedOrder = 4;
-
-  dlong Nlocal = Nelements*Np*Nfields;
-  dlong Ntotal = (Nelements+NhaloElements)*Np*Nfields;
-
-  o_rkq    = platform.malloc<dfloat>(Ntotal);
-  o_rhsq   = platform.malloc<dfloat>(Nlocal);
-  o_rkrhsq = platform.malloc<dfloat>(Nlocal*Nrk);
-  o_rkpmlq    = platform.malloc<dfloat>(Npml);
-  o_rhspmlq   = platform.malloc<dfloat>(Npml);
-  o_rkrhspmlq = platform.malloc<dfloat>(Npml*Nrk);
-
-  o_rkerr  = platform.malloc<dfloat>(Nlocal);
-
-  o_saveq  = platform.malloc<dfloat>(Nlocal);
-  o_savepmlq   = platform.malloc<dfloat>(Npml);
-
-  const int blocksize=256;
-
-  Nblock = (N+blocksize-1)/blocksize;
-  h_errtmp = platform.hostMalloc<dfloat>(Nblock);
-  o_errtmp = platform.malloc<dfloat>(Nblock);
-
-  hlong gNtotal = Nlocal;
-  comm.Allreduce(gNtotal);
-
-  properties_t kernelInfo = platform.props(); //copy base occa properties from solver
-
-  //add defines
-  kernelInfo["defines/" "p_blockSize"] = (int)blocksize;
-  kernelInfo["defines/" "p_Nrk"]     = (int)Nrk;
-  kernelInfo["defines/" "p_Np"]      = (int)Np;
-  kernelInfo["defines/" "p_Nfields"] = (int)Nfields;
-
-  rkUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
-                                    "timeStepperSARK.okl",
-                                    "sarkRkUpdate",
-                                    kernelInfo);
-  rkPmlUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
-                                      "timeStepperSARK.okl",
-                                      "sarkRkPmlUpdate",
-                                      kernelInfo);
-  rkStageKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
-                                    "timeStepperSARK.okl",
-                                    "sarkRkStage",
-                                    kernelInfo);
-  rkPmlStageKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
-                                      "timeStepperSARK.okl",
-                                      "sarkRkPmlStage",
-                                      kernelInfo);
-  rkErrorEstimateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
-                                    "timeStepperSARK.okl",
-                                    "sarkErrorEstimate",
-                                    kernelInfo);
-
-  // Semi-Analytic Runge Kutta - order (4) 5 with PID timestep control
-  dfloat _rkC[Nrk] = {0.0, 0.25, 0.25, 0.5, 0.75, 1.0, 1.0};
-  rkC.malloc(Nrk);
-  rkC.copyFrom(_rkC);
-
-  h_rkX = platform.hostMalloc<dfloat>(Nfields*Nrk);
-  h_rkA = platform.hostMalloc<dfloat>(Nfields*Nrk*Nrk);
-  h_rkE = platform.hostMalloc<dfloat>(Nfields*Nrk);
-
-  o_rkX = platform.malloc<dfloat>(Nfields*Nrk);
-  o_rkA = platform.malloc<dfloat>(Nfields*Nrk*Nrk);
-  o_rkE = platform.malloc<dfloat>(Nfields*Nrk);
-
-  pmlrkA.malloc(Nrk*Nrk);
-
-  dfloat _pmlrkA[Nrk*Nrk] =  {     0,      0,       0,       0,       0,      0,   0,
-                                 1/4,      0,       0,       0,       0,      0,   0,
-                                 1/8,    1/8,       0,       0,       0,      0,   0,
-                                   0,      0,     1/2,       0,       0,      0,   0,
-                              3./16., -3./8.,   3./8.,  9./16.,       0,      0,   0,
-                              -3./7.,  8./7.,   6./7., -12./7.,   8./7.,      0,   0,
-                              7./90.,     0., 16./45.,  2./15., 16./45., 7./90.,   0};
-
-  pmlrkA.copyFrom(_pmlrkA);
-
-  o_pmlrkA = platform.malloc<dfloat>(pmlrkA);
-
-  dtMIN = 1E-9; //minumum allowed timestep
-  ATOL = 1E-5;  //absolute error tolerance
-  RTOL = 1E-4;  //relative error tolerance
-  safe = 0.90;   //safety factor
-
-  //error control parameters
-  beta = 0.05;
-  factor1 = 0.2;
-  factor2 = 10.0;
-
-  exp1 = 1.0/(embeddedOrder) - 0.75*beta;
-  invfactor1 = 1.0/factor1;
-  invfactor2 = 1.0/factor2;
-  facold = 1E-4;
-  sqrtinvNtotal = 1.0/sqrt(gNtotal);
-}
-
-void sark5_pml::Run(solver_t& solver,
-                    deviceMemory<dfloat> &o_q,
-                    deviceMemory<dfloat> &o_pmlq,
-                    dfloat start, dfloat end) {
-
-  dfloat time = start;
-
-  solver.Report(time,0);
-
-  dfloat outputInterval=0.0;
-  solver.settings.getSetting("OUTPUT INTERVAL", outputInterval);
-
-  dfloat outputTime = time + outputInterval;
-
-  int tstep=0, allStep=0;
-
-  //Compute Butcher Tableau
-  UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
 
   // move data to platform
   h_rkX.copyTo(o_rkX, properties_t("async", true));
   h_rkA.copyTo(o_rkA, properties_t("async", true));
   h_rkE.copyTo(o_rkE, properties_t("async", true));
-
-  while (time < end) {
-
-    LIBP_ABORT("Time step became too small at time step = " << tstep,
-               dt<dtMIN);
-    LIBP_ABORT("Solution became unstable at time step = " << tstep,
-               std::isnan(dt));
-
-    //check for final timestep
-    if (time+dt > end){
-      dt = end-time;
-    }
-
-    Step(solver, o_q, o_pmlq, time, dt);
-
-    // compute Dopri estimator
-    dfloat err = Estimater(o_q);
-
-    // build controller
-    dfloat fac1 = pow(err,exp1);
-    dfloat fac = fac1/pow(facold,beta);
-
-    fac = std::max(invfactor2, std::min(invfactor1,fac/safe));
-    dfloat dtnew = dt/fac;
-
-    if (err<1.0) { //dt is accepted
-
-      // check for output during this step and do a mini-step
-      if (time<outputTime && time+dt>=outputTime) {
-        dfloat savedt = dt;
-
-        // save rkq
-        Backup(o_rkq, o_rkpmlq);
-
-        // change dt to match output
-        dt = outputTime-time;
-
-        //Compute Butcher Tableau
-        UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
-
-        // move data to platform
-        h_rkX.copyTo(o_rkX, properties_t("async", true));
-        h_rkA.copyTo(o_rkA, properties_t("async", true));
-        h_rkE.copyTo(o_rkE, properties_t("async", true));
-
-        // time step to output
-        Step(solver, o_q, o_pmlq, time, dt);
-
-        // shift for output
-        o_rkq.copyTo(o_q, properties_t("async", true));
-
-        // output  (print from rkq)
-        solver.Report(outputTime,tstep);
-
-        // restore time step
-        dt = savedt;
-
-        // increment next output time
-        outputTime += outputInterval;
-
-        // accept saved rkq
-        Restore(o_rkq, o_rkpmlq);
-        AcceptStep(o_q, o_rkq, o_pmlq, o_rkpmlq);
-
-      } else {
-        // accept rkq
-        AcceptStep(o_q, o_rkq, o_pmlq, o_rkpmlq);
-      }
-
-      time += dt;
-      while (time>outputTime) outputTime+= outputInterval; //catch up next output in case dt>outputInterval
-
-      constexpr dfloat errMax = 1.0e-4;  // hard coded factor ?
-      facold = std::max(err,errMax);
-
-      tstep++;
-    } else {
-      dtnew = dt/(std::max(invfactor1,fac1/safe));
-    }
-    dt = dtnew;
-
-    //Compute Butcher Tableau
-    UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
-
-    // move data to platform
-    h_rkX.copyTo(o_rkX, properties_t("async", true));
-    h_rkA.copyTo(o_rkA, properties_t("async", true));
-    h_rkE.copyTo(o_rkE, properties_t("async", true));
-
-    allStep++;
-  }
-}
-
-void sark5_pml::Backup(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq) {
-  o_saveq.copyFrom(o_q, N, properties_t("async", true));
-  o_savepmlq.copyFrom(o_rkpmlq, Npml, properties_t("async", true));
-}
-
-void sark5_pml::Restore(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq) {
-  o_saveq.copyTo(o_q, N, properties_t("async", true));
-  o_savepmlq.copyTo(o_rkpmlq, Npml, properties_t("async", true));
-}
-
-void sark5_pml::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq,
-                           deviceMemory<dfloat> &o_pmlq, deviceMemory<dfloat> &o_rpmlq) {
-  o_q.copyFrom(o_rq, N, properties_t("async", true));
-  o_pmlq.copyFrom(o_rpmlq, Npml, properties_t("async", true));
-}
-
-void sark5_pml::Step(solver_t& solver,
-                     deviceMemory<dfloat> &o_q,
-                     deviceMemory<dfloat> &o_pmlq,
-                     dfloat time, dfloat _dt) {
-
-  //RK step
-  for(int rk=0;rk<Nrk;++rk){
-
-    // t_rk = t + C_rk*_dt
-    dfloat currentTime = time + rkC[rk]*_dt;
-
-    //compute RK stage
-    // rkq = x_{rk}*q + _dt sum_{i=0}^{rk-1} a_{rk,i}*rhsq_i
-    rkStageKernel(Nelements,
-                  rk,
-                  _dt,
-                  o_rkX,
-                  o_rkA,
-                  o_q,
-                  o_rkrhsq,
-                  o_rkq);
-    if (Npml)
-      rkPmlStageKernel(Npml,
-                      rk,
-                      _dt,
-                      o_pmlrkA,
-                      o_pmlq,
-                      o_rkrhspmlq,
-                      o_rkpmlq);
-
-    //evaluate ODE rhs = f(q,t)
-    solver.rhsf_pml(o_rkq, o_rkpmlq, o_rhsq, o_rhspmlq, currentTime);
-
-    // update solution using Runge-Kutta
-    // rkrhsq_rk = rhsq
-    // if rk==6
-    //   q = rkX_{rk}*q + _dt*sum_{i=0}^{rk} rkA_{rk,i}*rkrhs_i
-    //   rkerr = _dt*sum_{i=0}^{rk} rkE_{rk,i}*rkrhs_i
-    rkUpdateKernel(Nelements,
-                   rk,
-                   _dt,
-                   o_rkX,
-                   o_rkA,
-                   o_rkE,
-                   o_q,
-                   o_rhsq,
-                   o_rkrhsq,
-                   o_rkq,
-                   o_rkerr);
-    if (Npml)
-      rkPmlUpdateKernel(Npml,
-                         rk,
-                         _dt,
-                         o_pmlrkA,
-                         o_pmlq,
-                         o_rhspmlq,
-                         o_rkrhspmlq,
-                         o_rkpmlq);
-  }
-}
-
-dfloat sark5_pml::Estimater(deviceMemory<dfloat>& o_q){
-
-  //Error estimation
-  //E. HAIRER, S.P. NORSETT AND G. WANNER, SOLVING ORDINARY
-  //      DIFFERENTIAL EQUATIONS I. NONSTIFF PROBLEMS. 2ND EDITION.
-  rkErrorEstimateKernel(Nelements*Np*Nfields,
-                        ATOL,
-                        RTOL,
-                        o_q,
-                        o_rkq,
-                        o_rkerr,
-                        o_errtmp);
-
-  h_errtmp.copyFrom(o_errtmp);
-  dfloat err = 0;
-  for(dlong n=0;n<Nblock;++n){
-    err += h_errtmp[n];
-  }
-  comm.Allreduce(err);
-
-  err = sqrt(err)*sqrtinvNtotal;
-
-  return err;
 }
 
 } //namespace TimeStepper

--- a/libs/timeStepper/timeStepperSARK5.cpp
+++ b/libs/timeStepper/timeStepperSARK5.cpp
@@ -35,6 +35,13 @@ namespace TimeStepper {
 
 using std::complex;
 
+static void UpdateCoefficients(const int Nfields,
+                               const memory<dfloat> &lambda,
+                               const dfloat dt,
+                               pinnedMemory<dfloat> &h_rkX,
+                               pinnedMemory<dfloat> &h_rkA,
+                               pinnedMemory<dfloat> &h_rkE);
+
 sark5::sark5(dlong _Nelements, dlong _NhaloElements,
              int _Np, int _Nfields,
              memory<dfloat> _lambda,
@@ -141,7 +148,15 @@ void sark5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
   int tstep=0, allStep=0;
 
   //Compute Butcher Tableau
-  UpdateCoefficients();
+  UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
+
+  // move data to platform
+  // o_rkX.copyFrom(rkX, properties_t("async", true));
+  // o_rkA.copyFrom(rkA, properties_t("async", true));
+  // o_rkE.copyFrom(rkE, properties_t("async", true));
+  h_rkX.copyTo(o_rkX);
+  h_rkA.copyTo(o_rkA);
+  h_rkE.copyTo(o_rkE);
 
   while (time < end) {
 
@@ -183,7 +198,15 @@ void sark5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
         //   printf("Taking output mini step: %g\n", dt);
 
         //Compute Butcher Tableau
-        UpdateCoefficients();
+        UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
+
+        // move data to platform
+        // o_rkX.copyFrom(rkX, properties_t("async", true));
+        // o_rkA.copyFrom(rkA, properties_t("async", true));
+        // o_rkE.copyFrom(rkE, properties_t("async", true));
+        h_rkX.copyTo(o_rkX);
+        h_rkA.copyTo(o_rkA);
+        h_rkE.copyTo(o_rkE);
 
         // time step to output
         Step(solver, o_q, time, dt);
@@ -231,7 +254,15 @@ void sark5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
     dt = dtnew;
 
     //Compute Butcher Tableau
-    UpdateCoefficients();
+    UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
+
+    // move data to platform
+    // o_rkX.copyFrom(rkX, properties_t("async", true));
+    // o_rkA.copyFrom(rkA, properties_t("async", true));
+    // o_rkE.copyFrom(rkE, properties_t("async", true));
+    h_rkX.copyTo(o_rkX);
+    h_rkA.copyTo(o_rkA);
+    h_rkE.copyTo(o_rkE);
 
     allStep++;
   }
@@ -240,12 +271,12 @@ void sark5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
     printf("%d accepted steps and %d total steps\n", tstep, allStep);
 }
 
-void sark5::Backup(deviceMemory<dfloat> &o_Q) {
-  o_saveq.copyFrom(o_Q, N);
+void sark5::Backup(deviceMemory<dfloat> &o_q) {
+  o_saveq.copyFrom(o_q, N);
 }
 
-void sark5::Restore(deviceMemory<dfloat> &o_Q) {
-  o_saveq.copyTo(o_Q, N);
+void sark5::Restore(deviceMemory<dfloat> &o_q) {
+  o_saveq.copyTo(o_q, N);
 }
 
 void sark5::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq) {
@@ -318,8 +349,14 @@ dfloat sark5::Estimater(deviceMemory<dfloat>& o_q){
   return err;
 }
 
-void sark5::UpdateCoefficients() {
+static void UpdateCoefficients(const int Nfields,
+                               const memory<dfloat> &lambda,
+                               const dfloat dt,
+                               pinnedMemory<dfloat> &h_rkX,
+                               pinnedMemory<dfloat> &h_rkA,
+                               pinnedMemory<dfloat> &h_rkE) {
 
+  constexpr int Nrk = 7;
   const int Nr = 32;
   complex<dfloat> R[Nr];
 
@@ -332,25 +369,25 @@ void sark5::UpdateCoefficients() {
 
   for (int n=0;n<Nfields;n++) {
 
+    dfloat* rkX = h_rkX.ptr() + n * Nrk;
+    dfloat* rkA = h_rkA.ptr() + n * Nrk * Nrk;
+    dfloat* rkE = h_rkE.ptr() + n * Nrk;
+
     if (lambda[n]==0) { //Zero exponential term, usual RK coefficients
 
-      dfloat _rkX[Nrk]   = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
-      dfloat _rkA[Nrk*Nrk]  =  {     0,      0,       0,       0,       0,      0,   0,
-                                   1/4,      0,       0,       0,       0,      0,   0,
-                                   1/8,    1/8,       0,       0,       0,      0,   0,
-                                     0,      0,     1/2,       0,       0,      0,   0,
-                                3./16., -3./8.,   3./8.,  9./16.,       0,      0,   0,
-                                -3./7.,  8./7.,   6./7., -12./7.,   8./7.,      0,   0,
-                                7./90.,     0., 16./45.,  2./15., 16./45., 7./90.,   0};
+      rkX[0] = 1.0; rkX[1] = 1.0; rkX[2] = 1.0; rkX[3] = 1.0; rkX[4] = 1.0; rkX[5] = 1.0; rkX[6] = 1.0;
 
-      dfloat _rkE[Nrk]=  {-4./45., 0, 16./45., -8./15., 16./45., -4./45., 0.};
+      rkA[0+0*Nrk] =     0.; rkA[1+0*Nrk] =     0.; rkA[2+0*Nrk] =      0.; rkA[3+0*Nrk] =      0.; rkA[4+0*Nrk] =      0.; rkA[5+0*Nrk] =     0.; rkA[6+0*Nrk] = 0.;
+      rkA[0+1*Nrk] =  1./4.; rkA[1+1*Nrk] =     0.; rkA[2+1*Nrk] =      0.; rkA[3+1*Nrk] =      0.; rkA[4+1*Nrk] =      0.; rkA[5+1*Nrk] =     0.; rkA[6+1*Nrk] = 0.;
+      rkA[0+2*Nrk] =  1./8.; rkA[1+2*Nrk] =  1./8.; rkA[2+2*Nrk] =      0.; rkA[3+2*Nrk] =      0.; rkA[4+2*Nrk] =      0.; rkA[5+2*Nrk] =     0.; rkA[6+2*Nrk] = 0.;
+      rkA[0+3*Nrk] =     0.; rkA[1+3*Nrk] =     0.; rkA[2+3*Nrk] =   1./2.; rkA[3+3*Nrk] =      0.; rkA[4+3*Nrk] =      0.; rkA[5+3*Nrk] =     0.; rkA[6+3*Nrk] = 0.;
+      rkA[0+4*Nrk] = 3./16.; rkA[1+4*Nrk] = -3./8.; rkA[2+4*Nrk] =   3./8.; rkA[3+4*Nrk] =  9./16.; rkA[4+4*Nrk] =      0.; rkA[5+4*Nrk] =     0.; rkA[6+4*Nrk] = 0.;
+      rkA[0+5*Nrk] = -3./7.; rkA[1+5*Nrk] =  8./7.; rkA[2+5*Nrk] =   6./7.; rkA[3+5*Nrk] = -12./7.; rkA[4+5*Nrk] =   8./7.; rkA[5+5*Nrk] =     0.; rkA[6+5*Nrk] = 0.;
+      rkA[0+6*Nrk] = 7./90.; rkA[1+6*Nrk] =     0.; rkA[2+6*Nrk] = 16./45.; rkA[3+6*Nrk] =  2./15.; rkA[4+6*Nrk] = 16./45.; rkA[5+6*Nrk] = 7./90.; rkA[6+6*Nrk] = 0.;
 
-      h_rkX.copyFrom(_rkX,    Nrk,n*Nrk    );
-      h_rkA.copyFrom(_rkA,Nrk*Nrk,n*Nrk*Nrk);
-      h_rkE.copyFrom(_rkE,    Nrk,n*Nrk    );
+      rkE[0] = -4./45.; rkE[1] = 0.; rkE[2] = 16./45.; rkE[3] = -8./15.; rkE[4] = 16./45.; rkE[5] = -4./45.; rkE[6] = 0.;
 
     } else {
-
       //Compute RK coefficients via contour integral
       dfloat alpha = lambda[n]*dt;
 
@@ -450,27 +487,267 @@ void sark5::UpdateCoefficients() {
       dfloat b4=real(cb4)/ (double) Nr;
       dfloat b6=real(cb6)/ (double) Nr;
 
-      dfloat _rkX[Nrk]  = {1.0,
-                           std::exp(dfloat(0.25)*alpha),
-                           std::exp(dfloat(0.25)*alpha),
-                           std::exp(dfloat(0.5)*alpha),
-                           std::exp(dfloat(0.75)*alpha),
-                           std::exp(alpha),
-                           std::exp(alpha)};
-      dfloat _rkA[Nrk*Nrk]={   0,   0,     0,     0,     0,    0,   0,
-                             a21,   0,     0,     0,     0,    0,   0,
-                             a31, a32,     0,     0,     0,    0,   0,
-                             a41,   0,   a43,     0,     0,    0,   0,
-                             a51, a52,   a53,   a54,     0,    0,   0,
-                             a61, a62,   a63,   a64,   a65,    0,   0,
-                             a71,   0,   a73,   a74,   a75,  a76,   0};
+      rkX[0] = 1.0; rkX[1] = std::exp(dfloat(0.25)*alpha); rkX[2] = std::exp(dfloat(0.25)*alpha); rkX[3] = std::exp(dfloat(0.5)*alpha); rkX[4] = std::exp(dfloat(0.75)*alpha); rkX[5] = std::exp(alpha); rkX[6] = std::exp(alpha);
 
-      dfloat _rkE[Nrk]= {b1, 0, b3, b4, a75, b6, 0};
+      rkA[0+0*Nrk] =  0.; rkA[1+0*Nrk] =  0.; rkA[2+0*Nrk] =  0.; rkA[3+0*Nrk] =  0.; rkA[4+0*Nrk] =  0.; rkA[5+0*Nrk] =  0.; rkA[6+0*Nrk] = 0.;
+      rkA[0+1*Nrk] = a21; rkA[1+1*Nrk] =  0.; rkA[2+1*Nrk] =  0.; rkA[3+1*Nrk] =  0.; rkA[4+1*Nrk] =  0.; rkA[5+1*Nrk] =  0.; rkA[6+1*Nrk] = 0.;
+      rkA[0+2*Nrk] = a31; rkA[1+2*Nrk] = a32; rkA[2+2*Nrk] =  0.; rkA[3+2*Nrk] =  0.; rkA[4+2*Nrk] =  0.; rkA[5+2*Nrk] =  0.; rkA[6+2*Nrk] = 0.;
+      rkA[0+3*Nrk] = a41; rkA[1+3*Nrk] =  0.; rkA[2+3*Nrk] = a43; rkA[3+3*Nrk] =  0.; rkA[4+3*Nrk] =  0.; rkA[5+3*Nrk] =  0.; rkA[6+3*Nrk] = 0.;
+      rkA[0+4*Nrk] = a51; rkA[1+4*Nrk] = a52; rkA[2+4*Nrk] = a53; rkA[3+4*Nrk] = a54; rkA[4+4*Nrk] =  0.; rkA[5+4*Nrk] =  0.; rkA[6+4*Nrk] = 0.;
+      rkA[0+5*Nrk] = a61; rkA[1+5*Nrk] = a62; rkA[2+5*Nrk] = a63; rkA[3+5*Nrk] = a64; rkA[4+5*Nrk] = a65; rkA[5+5*Nrk] =  0.; rkA[6+5*Nrk] = 0.;
+      rkA[0+6*Nrk] = a71; rkA[1+6*Nrk] =  0.; rkA[2+6*Nrk] = a73; rkA[3+6*Nrk] = a74; rkA[4+6*Nrk] = a75; rkA[5+6*Nrk] = a76; rkA[6+6*Nrk] = 0.;
 
-      h_rkX.copyFrom(_rkX,    Nrk,n*Nrk    );
-      h_rkA.copyFrom(_rkA,Nrk*Nrk,n*Nrk*Nrk);
-      h_rkE.copyFrom(_rkE,    Nrk,n*Nrk    );
+      rkE[0] = b1; rkE[1] = 0.; rkE[2] = b3; rkE[3] = b4; rkE[4] = a75; rkE[5] = b6; rkE[6] = 0.;
     }
+  }
+}
+
+/**************************************************/
+/* PML version                                    */
+/**************************************************/
+
+sark5_pml::sark5_pml(dlong _Nelements, dlong NpmlElements, dlong _NhaloElements,
+                     int _Np, int _Nfields, int Npmlfields,
+                     memory<dfloat> _lambda,
+                     platform_t& _platform, comm_t _comm):
+  pmlTimeStepperBase_t(_Nelements, NpmlElements, _NhaloElements,
+                       _Np, _Nfields, Npmlfields,
+                       _platform, _comm),
+  Np(_Np),
+  Nfields(_Nfields),
+  Nelements(_Nelements),
+  NhaloElements(_NhaloElements) {
+
+  lambda.malloc(Nfields);
+  lambda.copyFrom(_lambda);
+
+  //Nrk = 7; //number of stages
+  order = 5;
+  embeddedOrder = 4;
+
+  dlong Nlocal = Nelements*Np*Nfields;
+  dlong Ntotal = (Nelements+NhaloElements)*Np*Nfields;
+
+  o_rkq    = platform.malloc<dfloat>(Ntotal);
+  o_rhsq   = platform.malloc<dfloat>(Nlocal);
+  o_rkrhsq = platform.malloc<dfloat>(Nlocal*Nrk);
+  o_rkpmlq    = platform.malloc<dfloat>(Npml);
+  o_rhspmlq   = platform.malloc<dfloat>(Npml);
+  o_rkrhspmlq = platform.malloc<dfloat>(Npml*Nrk);
+
+  o_rkerr  = platform.malloc<dfloat>(Nlocal);
+
+  o_saveq  = platform.malloc<dfloat>(Nlocal);
+  o_savepmlq   = platform.malloc<dfloat>(Npml);
+
+  const int blocksize=256;
+
+  Nblock = (N+blocksize-1)/blocksize;
+  h_errtmp = platform.hostMalloc<dfloat>(Nblock);
+  o_errtmp = platform.malloc<dfloat>(Nblock);
+
+  hlong gNtotal = Nlocal;
+  comm.Allreduce(gNtotal);
+
+  properties_t kernelInfo = platform.props(); //copy base occa properties from solver
+
+  //add defines
+  kernelInfo["defines/" "p_blockSize"] = (int)blocksize;
+  kernelInfo["defines/" "p_Nrk"]     = (int)Nrk;
+  kernelInfo["defines/" "p_Np"]      = (int)Np;
+  kernelInfo["defines/" "p_Nfields"] = (int)Nfields;
+
+  rkUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+                                    "timeStepperSARK.okl",
+                                    "sarkRkUpdate",
+                                    kernelInfo);
+  rkPmlUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+                                      "timeStepperSARK.okl",
+                                      "sarkRkPmlUpdate",
+                                      kernelInfo);
+  rkStageKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+                                    "timeStepperSARK.okl",
+                                    "sarkRkStage",
+                                    kernelInfo);
+  rkPmlStageKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+                                      "timeStepperSARK.okl",
+                                      "sarkRkPmlStage",
+                                      kernelInfo);
+  rkErrorEstimateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
+                                    "timeStepperSARK.okl",
+                                    "sarkErrorEstimate",
+                                    kernelInfo);
+
+  // Semi-Analytic Runge Kutta - order (4) 5 with PID timestep control
+  dfloat _rkC[Nrk] = {0.0, 0.25, 0.25, 0.5, 0.75, 1.0, 1.0};
+  rkC.malloc(Nrk);
+  rkC.copyFrom(_rkC);
+
+  h_rkX = platform.hostMalloc<dfloat>(Nfields*Nrk);
+  h_rkA = platform.hostMalloc<dfloat>(Nfields*Nrk*Nrk);
+  h_rkE = platform.hostMalloc<dfloat>(Nfields*Nrk);
+
+  o_rkX = platform.malloc<dfloat>(Nfields*Nrk);
+  o_rkA = platform.malloc<dfloat>(Nfields*Nrk*Nrk);
+  o_rkE = platform.malloc<dfloat>(Nfields*Nrk);
+
+  pmlrkA.malloc(Nrk*Nrk);
+
+  dfloat _pmlrkA[Nrk*Nrk] =  {     0,      0,       0,       0,       0,      0,   0,
+                                 1/4,      0,       0,       0,       0,      0,   0,
+                                 1/8,    1/8,       0,       0,       0,      0,   0,
+                                   0,      0,     1/2,       0,       0,      0,   0,
+                              3./16., -3./8.,   3./8.,  9./16.,       0,      0,   0,
+                              -3./7.,  8./7.,   6./7., -12./7.,   8./7.,      0,   0,
+                              7./90.,     0., 16./45.,  2./15., 16./45., 7./90.,   0};
+
+  pmlrkA.copyFrom(_pmlrkA);
+
+  o_pmlrkA = platform.malloc<dfloat>(pmlrkA);
+
+  dtMIN = 1E-9; //minumum allowed timestep
+  ATOL = 1E-5;  //absolute error tolerance
+  RTOL = 1E-4;  //relative error tolerance
+  safe = 0.90;   //safety factor
+
+  //error control parameters
+  beta = 0.05;
+  factor1 = 0.2;
+  factor2 = 10.0;
+
+  exp1 = 1.0/(embeddedOrder) - 0.75*beta;
+  invfactor1 = 1.0/factor1;
+  invfactor2 = 1.0/factor2;
+  facold = 1E-4;
+  sqrtinvNtotal = 1.0/sqrt(gNtotal);
+}
+
+void sark5_pml::Run(solver_t& solver,
+                    deviceMemory<dfloat> &o_q,
+                    deviceMemory<dfloat> &o_pmlq,
+                    dfloat start, dfloat end) {
+
+  dfloat time = start;
+
+  int rank = comm.rank();
+
+  solver.Report(time,0);
+
+  dfloat outputInterval=0.0;
+  solver.settings.getSetting("OUTPUT INTERVAL", outputInterval);
+
+  dfloat outputTime = time + outputInterval;
+
+  int tstep=0, allStep=0;
+
+  //Compute Butcher Tableau
+  UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
+
+  // move data to platform
+  // o_rkX.copyFrom(rkX, properties_t("async", true));
+  // o_rkA.copyFrom(rkA, properties_t("async", true));
+  // o_rkE.copyFrom(rkE, properties_t("async", true));
+  h_rkX.copyTo(o_rkX);
+  h_rkA.copyTo(o_rkA);
+  h_rkE.copyTo(o_rkE);
+
+  while (time < end) {
+
+    LIBP_ABORT("Time step became too small at time step = " << tstep,
+               dt<dtMIN);
+    LIBP_ABORT("Solution became unstable at time step = " << tstep,
+               std::isnan(dt));
+
+    //check for final timestep
+    if (time+dt > end){
+      dt = end-time;
+    }
+
+    Step(solver, o_q, o_pmlq, time, dt);
+
+    // compute Dopri estimator
+    dfloat err = Estimater(o_q);
+
+    // build controller
+    dfloat fac1 = pow(err,exp1);
+    dfloat fac = fac1/pow(facold,beta);
+
+    fac = std::max(invfactor2, std::min(invfactor1,fac/safe));
+    dfloat dtnew = dt/fac;
+
+    if (err<1.0) { //dt is accepted
+
+      // check for output during this step and do a mini-step
+      if (time<outputTime && time+dt>=outputTime) {
+        dfloat savedt = dt;
+
+        // save rkq
+        Backup(o_rkq, o_rkpmlq);
+
+        // change dt to match output
+        dt = outputTime-time;
+
+        // if(!rank)
+        //   printf("Taking output mini step: %g\n", dt);
+
+        //Compute Butcher Tableau
+        UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
+
+        // move data to platform
+        // o_rkX.copyFrom(rkX, properties_t("async", true));
+        // o_rkA.copyFrom(rkA, properties_t("async", true));
+        // o_rkE.copyFrom(rkE, properties_t("async", true));
+        h_rkX.copyTo(o_rkX);
+        h_rkA.copyTo(o_rkA);
+        h_rkE.copyTo(o_rkE);
+
+        // time step to output
+        Step(solver, o_q, o_pmlq, time, dt);
+
+        // shift for output
+        o_rkq.copyTo(o_q);
+
+        // output  (print from rkq)
+        // if (!rank) printf("\n");
+        solver.Report(outputTime,tstep);
+
+        // restore time step
+        dt = savedt;
+
+        // increment next output time
+        outputTime += outputInterval;
+
+        // accept saved rkq
+        Restore(o_rkq, o_rkpmlq);
+        AcceptStep(o_q, o_rkq, o_pmlq, o_rkpmlq);
+
+      } else {
+        // accept rkq
+        AcceptStep(o_q, o_rkq, o_pmlq, o_rkpmlq);
+      }
+
+      time += dt;
+      while (time>outputTime) outputTime+= outputInterval; //catch up next output in case dt>outputInterval
+
+      constexpr dfloat errMax = 1.0e-4;  // hard coded factor ?
+      facold = std::max(err,errMax);
+
+      // if (!rank)
+      //   printf("\r time = %g (%d), dt = %g accepted                      ", time, allStep,  dt);
+
+      tstep++;
+    } else {
+      dtnew = dt/(std::max(invfactor1,fac1/safe));
+
+      // if (!rank)
+      //   printf("\r time = %g (%d), dt = %g rejected, trying %g", time, allStep, dt, dtnew);
+      if (!rank)
+        printf("Repeating timestep %d. dt was %g, trying %g.\n", tstep, dt, dtnew);
+    }
+    dt = dtnew;
+
+    //Compute Butcher Tableau
+    UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
 
     // move data to platform
     // o_rkX.copyFrom(rkX, properties_t("async", true));
@@ -479,86 +756,34 @@ void sark5::UpdateCoefficients() {
     h_rkX.copyTo(o_rkX);
     h_rkA.copyTo(o_rkA);
     h_rkE.copyTo(o_rkE);
+
+    allStep++;
   }
+
+  if (!rank)
+    printf("%d accepted steps and %d total steps\n", tstep, allStep);
 }
 
-/**************************************************/
-/* PML version                                    */
-/**************************************************/
-
-sark5_pml::sark5_pml(dlong _Nelements, dlong _NpmlElements, dlong _NhaloElements,
-            int _Np, int _Nfields, int _Npmlfields,
-            memory<dfloat> _lambda,
-            platform_t& _platform, comm_t _comm):
-  sark5(_Nelements, _NhaloElements, _Np, _Nfields, _lambda, _platform, _comm),
-  Npml(_Npmlfields*_Np*_NpmlElements) {
-
-  if (Npml) {
-    memory<dfloat> pmlq(Npml,0.0);
-    o_pmlq   = platform.malloc<dfloat>(pmlq);
-
-    o_rkpmlq    = platform.malloc<dfloat>(Npml);
-    o_rhspmlq   = platform.malloc<dfloat>(Npml);
-    o_rkrhspmlq = platform.malloc<dfloat>(Npml*Nrk);
-
-    o_savepmlq   = platform.malloc<dfloat>(Npml);
-
-    properties_t kernelInfo = platform.props(); //copy base occa properties from solver
-
-    const int blocksize=256;
-
-    //add defines
-    kernelInfo["defines/" "p_blockSize"] = (int)blocksize;
-    kernelInfo["defines/" "p_Nrk"]     = (int)Nrk;
-    kernelInfo["defines/" "p_Np"]      = (int)Np;
-    kernelInfo["defines/" "p_Nfields"] = (int)Nfields;
-
-    rkPmlUpdateKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
-                                      "timeStepperSARK.okl",
-                                      "sarkRkPmlUpdate",
-                                      kernelInfo);
-
-    rkPmlStageKernel = platform.buildKernel(TIMESTEPPER_DIR "/okl/"
-                                      "timeStepperSARK.okl",
-                                      "sarkRkPmlStage",
-                                      kernelInfo);
-
-    // Semi-Analytic Runge Kutta - order (3) 4 with PID timestep control
-    pmlrkA.malloc(Nrk*Nrk);
-
-    dfloat _pmlrkA[Nrk*Nrk] =  {     0,      0,       0,       0,       0,      0,   0,
-                                   1/4,      0,       0,       0,       0,      0,   0,
-                                   1/8,    1/8,       0,       0,       0,      0,   0,
-                                     0,      0,     1/2,       0,       0,      0,   0,
-                                3./16., -3./8.,   3./8.,  9./16.,       0,      0,   0,
-                                -3./7.,  8./7.,   6./7., -12./7.,   8./7.,      0,   0,
-                                7./90.,     0., 16./45.,  2./15., 16./45., 7./90.,   0};
-
-    pmlrkA.copyFrom(_pmlrkA);
-
-    o_pmlrkA = platform.malloc<dfloat>(pmlrkA);
-  }
+void sark5_pml::Backup(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq) {
+  o_saveq.copyFrom(o_q, N);
+  o_savepmlq.copyFrom(o_rkpmlq, Npml);
 }
 
-void sark5_pml::Backup(deviceMemory<dfloat> &o_Q) {
-  o_saveq.copyFrom(o_Q, N);
-  if (Npml)
-    o_savepmlq.copyFrom(o_rkpmlq, Npml);
+void sark5_pml::Restore(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq) {
+  o_saveq.copyTo(o_q, N);
+  o_savepmlq.copyTo(o_rkpmlq, Npml);
 }
 
-void sark5_pml::Restore(deviceMemory<dfloat> &o_Q) {
-  o_saveq.copyTo(o_Q, N);
-  if (Npml)
-    o_savepmlq.copyTo(o_rkpmlq, Npml);
-}
-
-void sark5_pml::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq) {
+void sark5_pml::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq,
+                           deviceMemory<dfloat> &o_pmlq, deviceMemory<dfloat> &o_rpmlq) {
   o_q.copyFrom(o_rq, N);
-  if (Npml)
-    o_pmlq.copyFrom(o_rkpmlq, Npml);
+  o_pmlq.copyFrom(o_rpmlq, Npml);
 }
 
-void sark5_pml::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloat _dt) {
+void sark5_pml::Step(solver_t& solver,
+                     deviceMemory<dfloat> &o_q,
+                     deviceMemory<dfloat> &o_pmlq,
+                     dfloat time, dfloat _dt) {
 
   //RK step
   for(int rk=0;rk<Nrk;++rk){
@@ -576,7 +801,6 @@ void sark5_pml::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, d
                   o_q,
                   o_rkrhsq,
                   o_rkq);
-
     if (Npml)
       rkPmlStageKernel(Npml,
                       rk,
@@ -615,6 +839,31 @@ void sark5_pml::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, d
                          o_rkrhspmlq,
                          o_rkpmlq);
   }
+}
+
+dfloat sark5_pml::Estimater(deviceMemory<dfloat>& o_q){
+
+  //Error estimation
+  //E. HAIRER, S.P. NORSETT AND G. WANNER, SOLVING ORDINARY
+  //      DIFFERENTIAL EQUATIONS I. NONSTIFF PROBLEMS. 2ND EDITION.
+  rkErrorEstimateKernel(Nelements*Np*Nfields,
+                        ATOL,
+                        RTOL,
+                        o_q,
+                        o_rkq,
+                        o_rkerr,
+                        o_errtmp);
+
+  h_errtmp.copyFrom(o_errtmp);
+  dfloat err = 0;
+  for(dlong n=0;n<Nblock;++n){
+    err += h_errtmp[n];
+  }
+  comm.Allreduce(err);
+
+  err = sqrt(err)*sqrtinvNtotal;
+
+  return err;
 }
 
 } //namespace TimeStepper

--- a/libs/timeStepper/timeStepperSARK5.cpp
+++ b/libs/timeStepper/timeStepperSARK5.cpp
@@ -136,8 +136,6 @@ void sark5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
 
   dfloat time = start;
 
-  int rank = comm.rank();
-
   solver.Report(time,0);
 
   dfloat outputInterval=0.0;
@@ -151,12 +149,9 @@ void sark5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
   UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
 
   // move data to platform
-  // o_rkX.copyFrom(rkX, properties_t("async", true));
-  // o_rkA.copyFrom(rkA, properties_t("async", true));
-  // o_rkE.copyFrom(rkE, properties_t("async", true));
-  h_rkX.copyTo(o_rkX);
-  h_rkA.copyTo(o_rkA);
-  h_rkE.copyTo(o_rkE);
+  h_rkX.copyTo(o_rkX, properties_t("async", true));
+  h_rkA.copyTo(o_rkA, properties_t("async", true));
+  h_rkE.copyTo(o_rkE, properties_t("async", true));
 
   while (time < end) {
 
@@ -194,28 +189,21 @@ void sark5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
         // change dt to match output
         dt = outputTime-time;
 
-        // if(!rank)
-        //   printf("Taking output mini step: %g\n", dt);
-
         //Compute Butcher Tableau
         UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
 
         // move data to platform
-        // o_rkX.copyFrom(rkX, properties_t("async", true));
-        // o_rkA.copyFrom(rkA, properties_t("async", true));
-        // o_rkE.copyFrom(rkE, properties_t("async", true));
-        h_rkX.copyTo(o_rkX);
-        h_rkA.copyTo(o_rkA);
-        h_rkE.copyTo(o_rkE);
+        h_rkX.copyTo(o_rkX, properties_t("async", true));
+        h_rkA.copyTo(o_rkA, properties_t("async", true));
+        h_rkE.copyTo(o_rkE, properties_t("async", true));
 
         // time step to output
         Step(solver, o_q, time, dt);
 
         // shift for output
-        o_rkq.copyTo(o_q);
+        o_rkq.copyTo(o_q, properties_t("async", true));
 
         // output  (print from rkq)
-        // if (!rank) printf("\n");
         solver.Report(outputTime,tstep);
 
         // restore time step
@@ -239,17 +227,9 @@ void sark5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
       constexpr dfloat errMax = 1.0e-4;  // hard coded factor ?
       facold = std::max(err,errMax);
 
-      // if (!rank)
-      //   printf("\r time = %g (%d), dt = %g accepted                      ", time, allStep,  dt);
-
       tstep++;
     } else {
       dtnew = dt/(std::max(invfactor1,fac1/safe));
-
-      // if (!rank)
-      //   printf("\r time = %g (%d), dt = %g rejected, trying %g", time, allStep, dt, dtnew);
-      if (!rank)
-        printf("Repeating timestep %d. dt was %g, trying %g.\n", tstep, dt, dtnew);
     }
     dt = dtnew;
 
@@ -257,30 +237,24 @@ void sark5::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloa
     UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
 
     // move data to platform
-    // o_rkX.copyFrom(rkX, properties_t("async", true));
-    // o_rkA.copyFrom(rkA, properties_t("async", true));
-    // o_rkE.copyFrom(rkE, properties_t("async", true));
-    h_rkX.copyTo(o_rkX);
-    h_rkA.copyTo(o_rkA);
-    h_rkE.copyTo(o_rkE);
+    h_rkX.copyTo(o_rkX, properties_t("async", true));
+    h_rkA.copyTo(o_rkA, properties_t("async", true));
+    h_rkE.copyTo(o_rkE, properties_t("async", true));
 
     allStep++;
   }
-
-  if (!rank)
-    printf("%d accepted steps and %d total steps\n", tstep, allStep);
 }
 
 void sark5::Backup(deviceMemory<dfloat> &o_q) {
-  o_saveq.copyFrom(o_q, N);
+  o_saveq.copyFrom(o_q, N, properties_t("async", true));
 }
 
 void sark5::Restore(deviceMemory<dfloat> &o_q) {
-  o_saveq.copyTo(o_q, N);
+  o_saveq.copyTo(o_q, N, properties_t("async", true));
 }
 
 void sark5::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq) {
-  o_q.copyFrom(o_rq, N);
+  o_q.copyFrom(o_rq, N, properties_t("async", true));
 }
 
 void sark5::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloat _dt) {
@@ -629,8 +603,6 @@ void sark5_pml::Run(solver_t& solver,
 
   dfloat time = start;
 
-  int rank = comm.rank();
-
   solver.Report(time,0);
 
   dfloat outputInterval=0.0;
@@ -644,12 +616,9 @@ void sark5_pml::Run(solver_t& solver,
   UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
 
   // move data to platform
-  // o_rkX.copyFrom(rkX, properties_t("async", true));
-  // o_rkA.copyFrom(rkA, properties_t("async", true));
-  // o_rkE.copyFrom(rkE, properties_t("async", true));
-  h_rkX.copyTo(o_rkX);
-  h_rkA.copyTo(o_rkA);
-  h_rkE.copyTo(o_rkE);
+  h_rkX.copyTo(o_rkX, properties_t("async", true));
+  h_rkA.copyTo(o_rkA, properties_t("async", true));
+  h_rkE.copyTo(o_rkE, properties_t("async", true));
 
   while (time < end) {
 
@@ -687,28 +656,21 @@ void sark5_pml::Run(solver_t& solver,
         // change dt to match output
         dt = outputTime-time;
 
-        // if(!rank)
-        //   printf("Taking output mini step: %g\n", dt);
-
         //Compute Butcher Tableau
         UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
 
         // move data to platform
-        // o_rkX.copyFrom(rkX, properties_t("async", true));
-        // o_rkA.copyFrom(rkA, properties_t("async", true));
-        // o_rkE.copyFrom(rkE, properties_t("async", true));
-        h_rkX.copyTo(o_rkX);
-        h_rkA.copyTo(o_rkA);
-        h_rkE.copyTo(o_rkE);
+        h_rkX.copyTo(o_rkX, properties_t("async", true));
+        h_rkA.copyTo(o_rkA, properties_t("async", true));
+        h_rkE.copyTo(o_rkE, properties_t("async", true));
 
         // time step to output
         Step(solver, o_q, o_pmlq, time, dt);
 
         // shift for output
-        o_rkq.copyTo(o_q);
+        o_rkq.copyTo(o_q, properties_t("async", true));
 
         // output  (print from rkq)
-        // if (!rank) printf("\n");
         solver.Report(outputTime,tstep);
 
         // restore time step
@@ -732,17 +694,9 @@ void sark5_pml::Run(solver_t& solver,
       constexpr dfloat errMax = 1.0e-4;  // hard coded factor ?
       facold = std::max(err,errMax);
 
-      // if (!rank)
-      //   printf("\r time = %g (%d), dt = %g accepted                      ", time, allStep,  dt);
-
       tstep++;
     } else {
       dtnew = dt/(std::max(invfactor1,fac1/safe));
-
-      // if (!rank)
-      //   printf("\r time = %g (%d), dt = %g rejected, trying %g", time, allStep, dt, dtnew);
-      if (!rank)
-        printf("Repeating timestep %d. dt was %g, trying %g.\n", tstep, dt, dtnew);
     }
     dt = dtnew;
 
@@ -750,34 +704,28 @@ void sark5_pml::Run(solver_t& solver,
     UpdateCoefficients(Nfields, lambda, dt, h_rkX, h_rkA, h_rkE);
 
     // move data to platform
-    // o_rkX.copyFrom(rkX, properties_t("async", true));
-    // o_rkA.copyFrom(rkA, properties_t("async", true));
-    // o_rkE.copyFrom(rkE, properties_t("async", true));
-    h_rkX.copyTo(o_rkX);
-    h_rkA.copyTo(o_rkA);
-    h_rkE.copyTo(o_rkE);
+    h_rkX.copyTo(o_rkX, properties_t("async", true));
+    h_rkA.copyTo(o_rkA, properties_t("async", true));
+    h_rkE.copyTo(o_rkE, properties_t("async", true));
 
     allStep++;
   }
-
-  if (!rank)
-    printf("%d accepted steps and %d total steps\n", tstep, allStep);
 }
 
 void sark5_pml::Backup(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq) {
-  o_saveq.copyFrom(o_q, N);
-  o_savepmlq.copyFrom(o_rkpmlq, Npml);
+  o_saveq.copyFrom(o_q, N, properties_t("async", true));
+  o_savepmlq.copyFrom(o_rkpmlq, Npml, properties_t("async", true));
 }
 
 void sark5_pml::Restore(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_pmlq) {
-  o_saveq.copyTo(o_q, N);
-  o_savepmlq.copyTo(o_rkpmlq, Npml);
+  o_saveq.copyTo(o_q, N, properties_t("async", true));
+  o_savepmlq.copyTo(o_rkpmlq, Npml, properties_t("async", true));
 }
 
 void sark5_pml::AcceptStep(deviceMemory<dfloat> &o_q, deviceMemory<dfloat> &o_rq,
                            deviceMemory<dfloat> &o_pmlq, deviceMemory<dfloat> &o_rpmlq) {
-  o_q.copyFrom(o_rq, N);
-  o_pmlq.copyFrom(o_rpmlq, Npml);
+  o_q.copyFrom(o_rq, N, properties_t("async", true));
+  o_pmlq.copyFrom(o_rpmlq, Npml, properties_t("async", true));
 }
 
 void sark5_pml::Step(solver_t& solver,

--- a/libs/timeStepper/timeStepperSSBDF3.cpp
+++ b/libs/timeStepper/timeStepperSSBDF3.cpp
@@ -108,7 +108,7 @@ void ssbdf3::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dflo
 
   //put current q into history
   deviceMemory<dfloat> o_qn0 = o_qn + shiftIndex*N;
-  o_qn0.copyFrom(o_q, N);
+  o_qn0.copyFrom(o_q, N, properties_t("async", true));
 
   // Compute qhat = sum_i=1^s B_i qhat(t_n+1-i) by
   // where qhat(t) is the Lagrangian state of q

--- a/libs/timeStepper/timeStepperSSBDF3.cpp
+++ b/libs/timeStepper/timeStepperSSBDF3.cpp
@@ -35,7 +35,8 @@ namespace TimeStepper {
 ssbdf3::ssbdf3(dlong Nelements, dlong NhaloElements,
                  int Np, int Nfields,
                  platform_t& _platform, comm_t _comm):
-  timeStepperBase_t(Nelements, NhaloElements, Np, Nfields,
+  timeStepperBase_t(Nelements, 0, NhaloElements,
+                    Np, Nfields, 0,
                     _platform, _comm) {
 
   //Nstages = 3;
@@ -73,7 +74,13 @@ dfloat ssbdf3::GetGamma() {
   return ssbdf_b[(Nstages-1)*(Nstages+1)]; //first entry of last row of B
 }
 
-void ssbdf3::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dfloat end) {
+void ssbdf3::Run(solver_t& solver,
+                 deviceMemory<dfloat> o_q,
+                 std::optional<deviceMemory<dfloat>> o_pmlq,
+                 dfloat start, dfloat end) {
+
+  LIBP_ABORT("ssbdf3 timeStepper does not support PMLs",
+             o_pmlq.has_value());
 
   dfloat time = start;
 
@@ -100,7 +107,9 @@ void ssbdf3::Run(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat start, dflo
   }
 }
 
-void ssbdf3::Step(solver_t& solver, deviceMemory<dfloat> &o_q, dfloat time, dfloat _dt, int order) {
+void ssbdf3::Step(solver_t& solver,
+                  deviceMemory<dfloat> o_q,
+                  dfloat time, dfloat _dt, int order) {
 
   //BDF coefficients at current order
   deviceMemory<dfloat> o_B = o_ssbdf_b + order*(Nstages+1);

--- a/solvers/bns/bns.hpp
+++ b/solvers/bns/bns.hpp
@@ -54,7 +54,7 @@ public:
   int Nfields;
   int Npmlfields;
 
-  pmlTimeStepper_t timeStepper;
+  timeStepper_t timeStepper;
 
   ogs::halo_t traceHalo;
   memory<ogs::halo_t> multirateTraceHalo;

--- a/solvers/bns/bns.hpp
+++ b/solvers/bns/bns.hpp
@@ -54,7 +54,7 @@ public:
   int Nfields;
   int Npmlfields;
 
-  timeStepper_t timeStepper;
+  pmlTimeStepper_t timeStepper;
 
   ogs::halo_t traceHalo;
   memory<ogs::halo_t> multirateTraceHalo;
@@ -76,6 +76,9 @@ public:
   memory<dfloat> q;
   deviceMemory<dfloat> o_q;
 
+  memory<dfloat> pmlq;
+  deviceMemory<dfloat> o_pmlq;
+
   deviceMemory<dfloat> o_Mq;
 
   memory<dfloat> Vort, VortMag;
@@ -94,6 +97,7 @@ public:
   kernel_t vorticityKernel;
 
   kernel_t initialConditionKernel;
+  kernel_t pmlInitialConditionKernel;
 
   bns_t() = default;
   bns_t(platform_t &_platform, mesh_t &_mesh,

--- a/solvers/bns/okl/bnsInitialCondition2D.okl
+++ b/solvers/bns/okl/bnsInitialCondition2D.okl
@@ -64,3 +64,23 @@ SOFTWARE.
     }
   }
 }
+
+@kernel void bnsPmlInitialCondition2D(const dlong pmlNelements,
+                                      const dfloat c,
+                                      const dfloat nu,
+                                      const dfloat time,
+                                      @restrict const  dfloat *  x,
+                                      @restrict const  dfloat *  y,
+                                      @restrict const  dfloat *  z,
+                                      @restrict        dfloat *  pmlq){
+
+  for(dlong e=0;e<pmlNelements;++e;@outer(0)){
+    for(int n=0;n<p_Np;++n;@inner(0)){
+      // Set pml fields to zero initially
+      const dlong pmlbase = e*p_Npmlfields*p_Np + n;
+      for(int fld = 0; fld<p_Npmlfields; fld++){
+        pmlq[pmlbase + fld*p_Np] = 0;
+      }
+    }
+  }
+}

--- a/solvers/bns/okl/bnsInitialCondition3D.okl
+++ b/solvers/bns/okl/bnsInitialCondition3D.okl
@@ -81,3 +81,23 @@ SOFTWARE.
     }
   }
 }
+
+@kernel void bnsPmlInitialCondition3D(const dlong pmlNelements,
+                                      const dfloat c,
+                                      const dfloat nu,
+                                      const dfloat time,
+                                      @restrict const  dfloat *  x,
+                                      @restrict const  dfloat *  y,
+                                      @restrict const  dfloat *  z,
+                                      @restrict        dfloat *  pmlq){
+
+  for(dlong e=0;e<pmlNelements;++e;@outer(0)){
+    for(int n=0;n<p_Np;++n;@inner(0)){
+      // Set pml fields to zero initially
+      const dlong pmlbase = e*p_Npmlfields*p_Np + n;
+      for(int fld = 0; fld<p_Npmlfields; fld++){
+        pmlq[pmlbase + fld*p_Np] = 0;
+      }
+    }
+  }
+}

--- a/solvers/bns/src/bnsRun.cpp
+++ b/solvers/bns/src/bnsRun.cpp
@@ -72,7 +72,7 @@ void bns_t::Run(){
 #endif
   timeStepper.SetTimeStep(dt);
 
-  timeStepper.Run(*this, o_q, o_pmlq, startTime, finalTime);
+  timeStepper.RunWithPml(*this, o_q, o_pmlq, startTime, finalTime);
 
   // output norm of final solution
   {

--- a/solvers/bns/src/bnsRun.cpp
+++ b/solvers/bns/src/bnsRun.cpp
@@ -41,6 +41,16 @@ void bns_t::Run(){
                          mesh.o_z,
                          o_q);
 
+  if (mesh.NpmlElements)
+    pmlInitialConditionKernel(mesh.NpmlElements,
+                             c,
+                             nu,
+                             startTime,
+                             mesh.o_x,
+                             mesh.o_y,
+                             mesh.o_z,
+                             o_pmlq);
+
   dfloat cfl=1.0;
   settings.getSetting("CFL NUMBER", cfl);
 
@@ -62,7 +72,7 @@ void bns_t::Run(){
 #endif
   timeStepper.SetTimeStep(dt);
 
-  timeStepper.Run(*this, o_q, startTime, finalTime);
+  timeStepper.Run(*this, o_q, o_pmlq, startTime, finalTime);
 
   // output norm of final solution
   {

--- a/solvers/bns/src/bnsSetup.cpp
+++ b/solvers/bns/src/bnsSetup.cpp
@@ -114,45 +114,45 @@ void bns_t::Setup(platform_t& _platform, mesh_t& _mesh,
   }
 
   if (settings.compareSetting("TIME INTEGRATOR","MRAB3")){
-    timeStepper.Setup<TimeStepper::mrab3_pml>(mesh.Nelements, mesh.NpmlElements,
-                                              mesh.totalHaloPairs,
-                                              mesh.Np, Nfields, Npmlfields,
-                                              platform, mesh);
+    timeStepper.Setup<TimeStepper::mrab3>(mesh.Nelements, mesh.NpmlElements,
+                                          mesh.totalHaloPairs,
+                                          mesh.Np, Nfields, Npmlfields,
+                                          platform, mesh);
   } else if (settings.compareSetting("TIME INTEGRATOR","MRSAAB3")){
-    timeStepper.Setup<TimeStepper::mrsaab3_pml>(mesh.Nelements, mesh.NpmlElements,
-                                                mesh.totalHaloPairs,
-                                                mesh.Np, Nfields, Npmlfields,
-                                                lambda, platform, mesh);
-  } else if (settings.compareSetting("TIME INTEGRATOR","SAAB3")) {
-    timeStepper.Setup<TimeStepper::saab3_pml>(mesh.Nelements, mesh.NpmlElements,
-                                              mesh.totalHaloPairs,
-                                              mesh.Np, Nfields, Npmlfields,
-                                              lambda, platform, comm);
-  } else if (settings.compareSetting("TIME INTEGRATOR","AB3")){
-    timeStepper.Setup<TimeStepper::ab3_pml>(mesh.Nelements, mesh.NpmlElements,
+    timeStepper.Setup<TimeStepper::mrsaab3>(mesh.Nelements, mesh.NpmlElements,
                                             mesh.totalHaloPairs,
                                             mesh.Np, Nfields, Npmlfields,
-                                            platform, comm);
+                                            lambda, platform, mesh);
+  } else if (settings.compareSetting("TIME INTEGRATOR","SAAB3")) {
+    timeStepper.Setup<TimeStepper::saab3>(mesh.Nelements, mesh.NpmlElements,
+                                          mesh.totalHaloPairs,
+                                          mesh.Np, Nfields, Npmlfields,
+                                          lambda, platform, comm);
+  } else if (settings.compareSetting("TIME INTEGRATOR","AB3")){
+    timeStepper.Setup<TimeStepper::ab3>(mesh.Nelements, mesh.NpmlElements,
+                                        mesh.totalHaloPairs,
+                                        mesh.Np, Nfields, Npmlfields,
+                                        platform, comm);
   } else if (settings.compareSetting("TIME INTEGRATOR","LSERK4")){
-    timeStepper.Setup<TimeStepper::lserk4_pml>(mesh.Nelements, mesh.NpmlElements,
-                                               mesh.totalHaloPairs,
-                                               mesh.Np, Nfields, Npmlfields,
-                                               platform, comm);
+    timeStepper.Setup<TimeStepper::lserk4>(mesh.Nelements, mesh.NpmlElements,
+                                           mesh.totalHaloPairs,
+                                           mesh.Np, Nfields, Npmlfields,
+                                           platform, comm);
   } else if (settings.compareSetting("TIME INTEGRATOR","DOPRI5")){
-    timeStepper.Setup<TimeStepper::dopri5_pml>(mesh.Nelements, mesh.NpmlElements,
-                                               mesh.totalHaloPairs,
-                                               mesh.Np, Nfields, Npmlfields,
-                                               platform, comm);
+    timeStepper.Setup<TimeStepper::dopri5>(mesh.Nelements, mesh.NpmlElements,
+                                           mesh.totalHaloPairs,
+                                           mesh.Np, Nfields, Npmlfields,
+                                           platform, comm);
   } else if (settings.compareSetting("TIME INTEGRATOR","SARK4")) {
-    timeStepper.Setup<TimeStepper::sark4_pml>(mesh.Nelements, mesh.NpmlElements,
-                                              mesh.totalHaloPairs,
-                                              mesh.Np, Nfields, Npmlfields,
-                                              lambda, platform, comm);
+    timeStepper.Setup<TimeStepper::sark4>(mesh.Nelements, mesh.NpmlElements,
+                                          mesh.totalHaloPairs,
+                                          mesh.Np, Nfields, Npmlfields,
+                                          lambda, platform, comm);
   } else if (settings.compareSetting("TIME INTEGRATOR","SARK5")) {
-    timeStepper.Setup<TimeStepper::sark5_pml>(mesh.Nelements, mesh.NpmlElements,
-                                              mesh.totalHaloPairs,
-                                              mesh.Np, Nfields, Npmlfields,
-                                              lambda, platform, comm);
+    timeStepper.Setup<TimeStepper::sark5>(mesh.Nelements, mesh.NpmlElements,
+                                          mesh.totalHaloPairs,
+                                          mesh.Np, Nfields, Npmlfields,
+                                          lambda, platform, comm);
   } else {
     LIBP_FORCE_ABORT("Requested TIME INTEGRATOR not found.");
   }

--- a/solvers/bns/src/bnsSetup.cpp
+++ b/solvers/bns/src/bnsSetup.cpp
@@ -96,12 +96,12 @@ void bns_t::Setup(platform_t& _platform, mesh_t& _mesh,
     y /=mesh.Nverts;
     z /=mesh.Nverts;
 
-    dfloat c = mymin(fabs(x),fabs(y));
+    dfloat f = std::min(fabs(x),fabs(y));
     if (mesh.dim==3)
-      c = mymin(c,fabs(z));
+      f = std::min(f,fabs(z));
 
-    c = std::max(0.5, c);
-    EtoDT[e] *= c;
+    f = std::max(0.5, f);
+    EtoDT[e] *= f;
 #endif
   }
 
@@ -166,6 +166,9 @@ void bns_t::Setup(platform_t& _platform, mesh_t& _mesh,
   // compute samples of q at interpolation nodes
   q.malloc(Nlocal+Nhalo, 0.0);
   o_q = platform.malloc<dfloat>(q);
+
+  pmlq.malloc(mesh.NpmlElements*mesh.Np*Npmlfields, 0.0);
+  o_pmlq = platform.malloc<dfloat>(pmlq);
 
   Vort.malloc(mesh.dim*mesh.Nelements*mesh.Np, 0.0);
   o_Vort = platform.malloc<dfloat>(Vort);
@@ -277,12 +280,19 @@ void bns_t::Setup(platform_t& _platform, mesh_t& _mesh,
 
   if (mesh.dim==2) {
     fileName   = oklFilePrefix + "bnsInitialCondition2D" + oklFileSuffix;
-    kernelName = "bnsInitialCondition2D";
+    initialConditionKernel = platform.buildKernel(fileName,
+                                                  "bnsInitialCondition2D",
+                                                  kernelInfo);
+    pmlInitialConditionKernel = platform.buildKernel(fileName,
+                                                  "bnsPmlInitialCondition2D",
+                                                  kernelInfo);
   } else {
     fileName   = oklFilePrefix + "bnsInitialCondition3D" + oklFileSuffix;
-    kernelName = "bnsInitialCondition3D";
+    initialConditionKernel = platform.buildKernel(fileName,
+                                                  "bnsInitialCondition3D",
+                                                  kernelInfo);
+    pmlInitialConditionKernel = platform.buildKernel(fileName,
+                                                  "bnsPmlInitialCondition3D",
+                                                  kernelInfo);
   }
-
-  initialConditionKernel = platform.buildKernel(fileName, kernelName,
-                                            kernelInfo);
 }

--- a/test/testBns.py
+++ b/test/testBns.py
@@ -37,7 +37,7 @@ def bnsSettings(rcformat="2.0", data_file=bnsData2D,
                viscosity=0.01, speed_of_sound=1.0,
                pml_order=4, pml_sigx=50, pml_sigy=50, pml_sigz=50,
                pml_type="COLLOCATION",
-               time_integrator="SARK4", cfl=1.0, start_time=0.0, final_time=0.1,
+               time_integrator="SARK4", cfl=1.0, start_time=0.0, final_time=1.0,
                output_to_file="FALSE"):
   return [setting_t("FORMAT", rcformat),
           setting_t("DATA FILE", data_file),
@@ -71,51 +71,51 @@ def main():
   failCount += test(name="testBnsTri",
                     cmd=bnsBin,
                     settings=bnsSettings(element=3,data_file=bnsData2D,dim=2),
-                    referenceNorm=14.2114867833305)
+                    referenceNorm=14.1678650321147)
 
   failCount += test(name="testBnsQuad",
                     cmd=bnsBin,
                     settings=bnsSettings(element=4,data_file=bnsData2D,dim=2),
-                    referenceNorm=14.2051862745618)
+                    referenceNorm=14.1705509612135)
 
   failCount += test(name="testBnsTet",
                     cmd=bnsBin,
                     settings=bnsSettings(element=6,data_file=bnsData3D,dim=3, degree=2),
-                    referenceNorm=52.4193877177605)
+                    referenceNorm=52.4124009946974)
 
   failCount += test(name="testBnsHex",
                     cmd=bnsBin,
                     settings=bnsSettings(element=12,data_file=bnsData3D,dim=3, degree=2),
-                    referenceNorm=52.4199503907978)
+                    referenceNorm=52.4129181436354)
 
   failCount += test(name="testBnsTri_pmlcub",
                     cmd=bnsBin,
                     settings=bnsSettings(element=3,data_file=bnsData2D,dim=2,
                                          pml_type="CUBATURE"),
-                    referenceNorm=14.2114867833305)
+                    referenceNorm=14.1678650320949)
 
   failCount += test(name="testBnsQuad_pmlcub",
                     cmd=bnsBin,
                     settings=bnsSettings(element=4,data_file=bnsData2D,dim=2,
                                          pml_type="CUBATURE"),
-                    referenceNorm=14.2051862745618)
+                    referenceNorm=14.1705509612153)
 
   failCount += test(name="testBnsTet_pmlcub",
                     cmd=bnsBin,
                     settings=bnsSettings(element=6,data_file=bnsData3D,dim=3, degree=2,
                                          pml_type="CUBATURE"),
-                    referenceNorm=52.4193877177605)
+                    referenceNorm=52.4124009956122)
 
   failCount += test(name="testBnsHex_pmlcub",
                     cmd=bnsBin,
                     settings=bnsSettings(element=12,data_file=bnsData3D,dim=3, degree=2,
                                          pml_type="CUBATURE"),
-                    referenceNorm=52.4199503907978)
+                    referenceNorm=52.4129181425445)
 
   failCount += test(name="testBnsTri_MPI", ranks=4,
                     cmd=bnsBin,
                     settings=bnsSettings(element=3,data_file=bnsData2D,dim=2,output_to_file="TRUE"),
-                    referenceNorm=14.2019468231955)
+                    referenceNorm=14.1733270718503)
 
   #clean up
   for file_name in os.listdir(testDir):

--- a/test/testTimeStepper.py
+++ b/test/testTimeStepper.py
@@ -68,49 +68,49 @@ def main():
                     cmd=bnsBin,
                     settings=bnsSettings(element=3,data_file=bnsData2D,dim=2,
                                          time_integrator="AB3", cfl=0.25),
-                    referenceNorm=14.2550696512202)
+                    referenceNorm=14.1736932675536)
 
   failCount += test(name="testTimeStepper_saab3_pml",
                     cmd=bnsBin,
                     settings=bnsSettings(element=3,data_file=bnsData2D,dim=2,
                                          time_integrator="SAAB3", cfl=0.25),
-                    referenceNorm=14.2550270959095)
+                    referenceNorm=14.1738323959046)
 
   failCount += test(name="testTimeStepper_dopri5_pml",
                     cmd=bnsBin,
                     settings=bnsSettings(element=3,data_file=bnsData2D,dim=2,
                                          time_integrator="DOPRI5"),
-                    referenceNorm=14.2550469661139)
+                    referenceNorm=14.1738198794709)
 
   failCount += test(name="testTimeStepper_lserk4_pml",
                     cmd=bnsBin,
                     settings=bnsSettings(element=3,data_file=bnsData2D,dim=2,
                                          time_integrator="LSERK4"),
-                    referenceNorm=14.2550469661139)
+                    referenceNorm=14.1738199354077)
 
   failCount += test(name="testTimeStepper_sark4_pml",
                     cmd=bnsBin,
                     settings=bnsSettings(element=3,data_file=bnsData2D,dim=2,
                                          time_integrator="SARK4"),
-                    referenceNorm=14.2114867833305)
+                    referenceNorm=14.1678650321147)
 
   failCount += test(name="testTimeStepper_sark5_pml",
                     cmd=bnsBin,
                     settings=bnsSettings(element=3,data_file=bnsData2D,dim=2,
                                          time_integrator="SARK5"),
-                    referenceNorm=14.2397306802799)
+                    referenceNorm=14.1732505506027)
 
   failCount += test(name="testTimeStepper_mrab3_pml",
                     cmd=bnsBin,
                     settings=bnsSettings(element=3,data_file=bnsData2D,dim=2,
                                          time_integrator="MRAB3", cfl=0.25),
-                    referenceNorm=14.2550696512202)
+                    referenceNorm=14.1736932675536)
 
   failCount += test(name="testTimeStepper_mrsaab3_pml",
                     cmd=bnsBin,
                     settings=bnsSettings(element=3,data_file=bnsData2D,dim=2,
                                          time_integrator="MRSAAB3", cfl=0.25),
-                    referenceNorm=14.2550270959095)
+                    referenceNorm=14.1738323959046)
 
   return failCount
 


### PR DESCRIPTION
Some cleanup in the TimeSteppers before adding in memory pool functionality. 

- ~Splits PML and non-PML timesteppers into distinct objects. Using inheritance here doesn't reduce much code duplication and makes the PML timesteppers harder to follow~ Walking this back a bit. Having the timesteppers split leads to a lot of code duplication. Instead, this unifies the pml and non-pml timestepping and using std::optional to toggle between the different run modes. 
- Solvers with PMLs also should pass their PML fields into the timestepper, rather than the timestepper creating them and assuming they're zero
- Avoid initializing time stepper workspaces to zero. Instead just guard some accesses in kernels. This also reduces data motion in some kernels. 
- Use async copies where possible to avoid unnecessary H<->D syncs
- Fixed a subtle bug in SARK timesteppers. Changed the bns tests to time step for longer to strengthen the test
